### PR TITLE
Add install rule to cmake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,4 +532,18 @@ else ()
                         "${GTEST_SOURCE_DIR}/googletest/include")
     target_link_libraries(draco_tests draco gtest)
   endif ()
+
+  # Collect all of the header files in the tree, and add an install rule for
+  # each.
+  file(GLOB_RECURSE draco_headers RELATIVE ${draco_root} "*.h")
+  foreach (filename ${draco_headers})
+    get_filename_component(file_directory ${filename} DIRECTORY)
+    install(FILES ${filename} DESTINATION
+            "${CMAKE_INSTALL_PREFIX}/include/draco/${file_directory}")
+  endforeach()
+
+  # Add install rules for lib and executable targets.
+  install(TARGETS dracodec draco DESTINATION "${CMAKE_INSTALL_PREFIX}/lib")
+  install(TARGETS draco_decoder draco_encoder DESTINATION
+          "${CMAKE_INSTALL_PREFIX}/bin")
 endif ()


### PR DESCRIPTION
Installs includes, libs, and executables.

Based on https://github.com/google/draco/pull/21