### PR TITLE
fixed threejs example vertex color normal

### DIFF
--- a/javascript/example/DRACOLoader.js
+++ b/javascript/example/DRACOLoader.js
@@ -177,8 +177,7 @@ THREE.DRACOLoader.prototype = {
             geometryBuffer.vertices[i + 1] = posAttributeData.GetValue(i + 1);
             geometryBuffer.vertices[i + 2] = posAttributeData.GetValue(i + 2);
             // Add color.
-            // 03/05/2017, mackuntu@: ThreeJS vertex colors need to be
-            // normalized to properly display
+            // ThreeJS vertex colors need to be normalized to properly display
             if (colorAttId != -1) {
               geometryBuffer.colors[i] = colAttributeData.GetValue(i) / 255;
               geometryBuffer.colors[i + 1] = colAttributeData.GetValue(i + 1) / 255;

--- a/javascript/example/DRACOLoader.js
+++ b/javascript/example/DRACOLoader.js
@@ -177,10 +177,12 @@ THREE.DRACOLoader.prototype = {
             geometryBuffer.vertices[i + 1] = posAttributeData.GetValue(i + 1);
             geometryBuffer.vertices[i + 2] = posAttributeData.GetValue(i + 2);
             // Add color.
+            // 03/05/2017, mackuntu@: ThreeJS vertex colors need to be
+            // normalized to properly display
             if (colorAttId != -1) {
-              geometryBuffer.colors[i] = colAttributeData.GetValue(i);
-              geometryBuffer.colors[i + 1] = colAttributeData.GetValue(i + 1);
-              geometryBuffer.colors[i + 2] = colAttributeData.GetValue(i + 2);
+              geometryBuffer.colors[i] = colAttributeData.GetValue(i) / 255;
+              geometryBuffer.colors[i + 1] = colAttributeData.GetValue(i + 1) / 255;
+              geometryBuffer.colors[i + 2] = colAttributeData.GetValue(i + 2) / 255;
             } else {
               // Default is white. This is faster than TypedArray.fill().
               geometryBuffer.colors[i] = 1.0;


### PR DESCRIPTION
Current example loader will not display vertex colors correctly, since color attribute data need to be normalized as a fraction of 255.