### PR TITLE
Simplify steps required to run example.

### DIFF
--- a/javascript/example/README
+++ b/javascript/example/README
@@ -4,23 +4,14 @@ file and visualize it through threejs's fancy 3D tools.
 
 How to run the example code:
 
-(1) Create your working directory, e.g. draco_example/.
+(1) Clone this project to a working directory, e.g. draco/.
 
-(2) Download the latest three.js file from:
-https://github.com/mrdoob/three.js/blob/dev/build/three.js
-You could clone the repository and copy three.js from build/ to your
-working directory.
-
-(3) Copy DRACOLoader.js and webgl_loader_draco.html from
-draco/javascript/example to your working directory. Copy draco_decoder.js
-from draco/javascript to your working directory.
-
-(4) From your working directory, start a local http server.
+(2) From your working directory, start a local http server.
 E.g, with Python, you could run "python -m SimpleHTTPServer".
 
-(5) Load webgl_loader_draco.html. You should be able to see an empty scene
-rendered by threejs.
+(3) Load javascript/example/webgl_loader_draco.html. You should be able to see
+an empty scene rendered by threejs.
 
-(6) Click "Choose File" to select a draco encoded file (.drc) and you should be
+(4) Click "Choose File" to select a draco encoded file (.drc) and you should be
 able to see the model. e.g. bunny.drc. This is model encoded using Draco
 default compression. The original ply is located here "testdata/bun_zipper.ply".

--- a/javascript/example/README
+++ b/javascript/example/README
@@ -6,7 +6,7 @@ How to run the example code:
 
 (1) Clone this project to a working directory, e.g. draco/.
 
-(2) From your working directory, start a local http server.
+(2) From the project's root directory, start a local http server.
 E.g, with Python, you could run "python -m SimpleHTTPServer".
 
 (3) Load javascript/example/webgl_loader_draco.html. You should be able to see

--- a/javascript/example/webgl_loader_draco.html
+++ b/javascript/example/webgl_loader_draco.html
@@ -41,8 +41,8 @@
         </div>
         <pre id="fileDisplayArea"><pre>
     </div>
-    <script src="three.js"></script>
-    <script src="draco_decoder.js"></script>
+    <script src="https://cdn.rawgit.com/mrdoob/three.js/r84/build/three.min.js"></script>
+    <script src="../draco_decoder.js"></script>
     <script src="DRACOLoader.js"></script>
     <script>
       'use strict';


### PR DESCRIPTION
I'd like to suggest simplifying the steps required to get an example running for newer users.

The proposed change would link to the latest stable version of three.js (r84) from a CDN, and use a relative link to the existing `draco_decoder.js` file.