### PR TITLE
Fix build for sqrt usage in vector.

### DIFF
--- a/core/vector_d.h
+++ b/core/vector_d.h
@@ -18,6 +18,7 @@
 #include <inttypes.h>
 #include <algorithm>
 #include <array>
+#include <cmath>
 
 #include "core/macros.h"
 


### PR DESCRIPTION
Adding cmath include to fix OSX build (issue #83).