### PR TITLE
Update parser_utils.cc

### DIFF
--- a/io/parser_utils.cc
+++ b/io/parser_utils.cc
@@ -51,7 +51,7 @@ void SkipWhitespace(DecoderBuffer *buffer) {
 }
 
 bool PeekWhitespace(DecoderBuffer *buffer, bool *end_reached) {
-  char c;
+  unsigned char c;
   if (!buffer->Peek(&c)) {
     *end_reached = true;
     return false;  // eof reached.


### PR DESCRIPTION
 When using isspace(c), c should be an unsigned char given __chvalidator() requires a valid ascii value ( c >= -1 && c <= 255) and throws an error in the case of a signed char value between -128 and -2.