### PR TITLE
Add empty homepage index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+---
+layout: home
+title: Draco 3D Graphics Compression
+---

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -4,7 +4,7 @@ title: "README: Draco Spec Authoring Information"
 ---
 
 <ol class="breadcrumb">
-  <li class=""><a href="/">Home</a></li>
+  <li class=""><a href="..">Home</a></li>
   <li class=""><a href=".">Draft Specification</a></li>
   <li class="">README</li>
 </ol>

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -6,7 +6,7 @@ version_date: Released 2017-xx-xx
 ---
 
 <ol class="breadcrumb">
-  <li class=""><a href="/">Home</a></li>
+  <li class=""><a href="..">Home</a></li>
   <li class="">Draft Specification</li>
 </ol>
 


### PR DESCRIPTION
Though homepage is rendered completely from a template,
it still needs an index.md to generate.

Also change subpage breadcrumb links to relative, so they
work in the GitHub Pages context. For example "/" points
to the Google Org's home rather than Draco's home, so use
"..", etc.