### PR TITLE
Fix homepage video cue point.

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -39,6 +39,9 @@
     <meta name="msapplication-TileImage" content="{{ 'artwork/favicon/ms-icon-144x144.png' | relative_url }}">
     <meta name="theme-color" content="#ffffff">
     <style>
+    footer {
+      margin-top: 4rem;
+    }
     </style>
   </head>
 
@@ -97,7 +100,7 @@
       <div class="row">
         <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-xs-18">
           <div class="embed-responsive embed-responsive-16by9">
-            <iframe width="560" height="315" src="https://www.youtube.com/embed/_l4UaUix8vA" allowfullscreen></iframe>
+            <iframe width="560" height="315" src="https://www.youtube.com/embed/_l4UaUix8vA?start=33" frameborder="0" allowfullscreen></iframe>
           </div>
         </div>
       </div>


### PR DESCRIPTION
YT linking tool offers custom start times on shared links but not embeds. Hackable, though.