### PR TITLE
At extra small widths (phones), stack jumbotron elements.

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -85,10 +85,10 @@
       <!-- Main component for a primary marketing message or call to action -->
       <div class="jumbotron">
         <div class="row">
-          <div class="col-md-3 col-sm-3 col-xs-4">
-            <img class="img-responsive center-block" src="artwork/draco3d-vert-360x274.png">
+          <div class="col-xs-12 col-sm-4 col-md-3">
+            <img class="img-responsive center-block jumbo-logo" src="artwork/draco3d-vert-360x274.png">
           </div>
-          <div class="col-md-9 col-sm-9 col-xs-12 text-center">
+          <div class="col-xs-12 col-sm-8 col-md-9 text-center">
             <p>Draco is an open-source library for compressing and decompressing 3D
             geometric meshes and point clouds. It is intended to improve the storage
             and transmission of 3D graphics.</p>


### PR DESCRIPTION
Homepage "jumbotron" (logo + statement) should align well on all
viewport sizes. Specifically on phones (<768px), logo and statement
should both take full width and stack (and center).

At tablet widths, distribute 1/3:2/3. At larger widths, 1/4:3/4.