### PR TITLE
Adapt spec-related pages to Bootstrap.

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,0 +1,6 @@
+      <div class="container">
+        <footer>
+          <hr>
+          <p>&copy; 2017 The Draco authors</p>
+        </footer>
+      </div> <!-- /container -->

--- a/docs/_layouts/spec-page.html
+++ b/docs/_layouts/spec-page.html
@@ -38,10 +38,21 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="{{ 'artwork/favicon/ms-icon-144x144.png' | relative_url }}">
     <meta name="theme-color" content="#ffffff">
+    <link rel="stylesheet" href="{{ 'assets/css/spec-style.css' | relative_url }}">
     <style>
-    footer {
-      margin-top: 4rem;
-    }
+      body {counter-reset: h2}
+      h2 {counter-reset: h3}
+      h3 {counter-reset: h4}
+      h4 {counter-reset: h5}
+      h5 {counter-reset: h6}
+
+      h2:before {counter-increment: h2; content: counter(h2) ". "}
+      h3:before {counter-increment: h3; content: counter(h2) "." counter(h3) ". "}
+      h4:before {counter-increment: h4; content: counter(h2) "." counter(h3) "." counter(h4) ". "}
+      h5:before {counter-increment: h5; content: counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) ". "}
+      h6:before {counter-increment: h6; content: counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) "." counter(h6) ". "}
+
+      h2.nocount:before, h3.nocount:before, h4.nocount:before, h5.nocount:before, h6.nocount:before { content: ""; counter-increment: none }
     </style>
   </head>
 
@@ -82,74 +93,11 @@
 
     <div class="container">
 
-      <!-- Main component for a primary marketing message or call to action -->
-      <div class="jumbotron">
         <div class="row">
-          <div class="col-xs-12 col-sm-4 col-md-3">
-            <img class="img-responsive center-block jumbo-logo" src="artwork/draco3d-vert-360x274.png">
-          </div>
-          <div class="col-xs-12 col-sm-8 col-md-9 text-center">
-            <p>Draco is an open-source library for compressing and decompressing 3D
-            geometric meshes and point clouds. It is intended to improve the storage
-            and transmission of 3D graphics.</p>
-            <p>
-              <a class="btn btn-md btn-primary pull-right" href="https://github.com/google/draco" role="button">View on GitHub &raquo;</a>
-           </p>
+          <div class="col-xs-12 col-sm-12 col-md-10 col-md-offset-1">
+          {{ content }}
           </div>
         </div>
-      </div>
-
-    </div>
-
-    <div class="container">
-
-      <div class="row">
-        <div class="col-md-10 col-md-offset-1">
-          <div class="col-md-4">
-            <h2>Take the Codelab</h2>
-            <p>Learn about compressing and viewing 3D models with Draco, and about different compression models and their effects. </p>
-            <p><a class="btn btn-default" href="https://codelabs.developers.google.com/codelabs/draco-3d/index.html" role="button">Codelab &raquo;</a></p>
-          </div>
-          <div class="col-md-4">
-            <h2>Draft Bitstream Spec</h2>
-            <p>View and contribute to the in-progress Draco <a href="spec">Bitstream Specification</a> and Decoding Guide. (Also see the <a href="spec/README.html">instructions</a> for authors.)</p>
-            <p><a class="btn btn-default" href="spec" role="button">Bitstream Spec &raquo;</a></p>
-          </div>
-          <div class="col-md-4">
-            <h2>Related Projects</h2>
-            <ul>
-              <li><a href="https://www.npmjs.com/package/draco3d"><b>NPM Package</b></a></li>
-              <li><a href="https://webvr.info/">WebVR</a></li>
-              <li><a href="https://www.khronos.org/gltf">Khronos glTF</a></li>
-              <li><a href="https://threejs.org/">three.js</a></li>
-            </ul>
-          </div>
-
-        </div>
-      </div>
-
-    </div>
-
-    <div class="container">
-      <div class="row">
-        <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-xs-18">
-          <hr>
-          <h3>YouTube: Comparing Draco to gzip</h3>
-          <div class="embed-responsive embed-responsive-16by9">
-            <iframe width="560" height="315" src="https://www.youtube.com/embed/6sOgrBWjkcQ" frameborder="0" allowfullscreen></iframe>
-          </div>
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col-md-10 col-md-offset-1 col-sm-10 col-sm-offset-1 col-xs-18">
-          <hr>
-          <h3>YouTube: Draco Announced on Google Developer Show</h3>
-          <div class="embed-responsive embed-responsive-16by9">
-            <iframe width="560" height="315" src="https://www.youtube.com/embed/_l4UaUix8vA?start=33" frameborder="0" allowfullscreen></iframe>
-          </div>
-        </div>
-      </div>
 
     </div> <!-- /container -->
 
@@ -162,6 +110,6 @@
     <script src="{{ 'assets/js/bootstrap.min.js' | relative_url }}"></script>
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="{{ 'assets/js/ie10-viewport-bug-workaround.js' | relative_url }}"></script>
-    {% include analytics.html%}
+    {% include analytics.html %}
   </body>
 </html>

--- a/docs/assets/css/spec-style.sass
+++ b/docs/assets/css/spec-style.sass
@@ -9,33 +9,6 @@ $monofont: 'Inconsolata', monospace
 $gridcolor: #ddd
 $gridweight: 2px
 
-body
-  font-family: Arial, sans-serif
-  margin: 5% 25% 10% 10%
-  line-height: 1.3
-
-a
-  color: navy
-  text-decoration: none
-  &:visited
-    color: navy
-    text-decoration: none
-  &:hover
-    text-decoration: underline
-
-pre
-  //font-family: $monofont
-  //border: $gridweight solid $gridcolor
-  //background-color: #f7f7f7
-  //padding: 1em
-  //margin-left: 1em
-  //overflow-x: auto
-
-code
-  //color: #060
-  //background-color: #f2f2f2
-  font-family: $monofont
-
 table
   border-collapse: collapse
   min-width: 50%
@@ -82,15 +55,62 @@ figure.highlight
 
 div.draco-syntax pre
   background-color: #fff
-  background-image: linear-gradient(90deg, transparent 580px, #abced4 580px, #abced4 582px, transparent 582px), linear-gradient($gridcolor .1em, transparent .1em)
+  background-image: linear-gradient(90deg, transparent 660px, #abced4 660px, #abced4 662px, transparent 582px), linear-gradient($gridcolor .1em, transparent .1em)
   background-size: 100% 1.3em
   border-left: $gridweight solid $gridcolor
   border-right: $gridweight solid $gridcolor
   border-bottom: $gridweight solid $gridcolor
   white-space: pre
   font-family: $monofont
-  font-size: 1em
-  padding-left: 1em
+  font-size: 14px
+  padding: 0 14px
+  line-height: 18px
   margin-left: 1em
-  width: 720px
+  width: 840px
   //overflow: auto
+
+ol.breadcrumb
+  background-color: #fff
+  padding-left: 0
+  font-size: 12px
+
+// Auto heading-number styles
+
+body
+  counter-reset: h2
+
+h2
+  counter-reset: h3
+
+h3
+  counter-reset: h4
+
+h4
+  counter-reset: h5
+
+h5
+  counter-reset: h6
+
+h2:before
+  counter-increment: h2
+  content: counter(h2) ". "
+
+h3:before
+  counter-increment: h3
+  content: counter(h2) "." counter(h3) ". "
+
+h4:before
+  counter-increment: h4
+  content: counter(h2) "." counter(h3) "." counter(h4) ". "
+
+h5:before
+  counter-increment: h5
+  content: counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) ". "
+
+h6:before
+  counter-increment: h6
+  content: counter(h2) "." counter(h3) "." counter(h4) "." counter(h5) "." counter(h6) ". "
+
+h2.nocount:before, h3.nocount:before, h4.nocount:before, h5.nocount:before, h6.nocount:before
+  content: ""
+  counter-increment: none

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,5 +1,5 @@
 ---
-layout: spec
+layout: spec-page
 title: "README: Draco Spec Authoring Information"
 ---
 
@@ -189,17 +189,17 @@ them up as follows:
    immediately after the code-block closing delimiter.
 
   * Some syntax elements as annotated with their type and size in a right-hand
-    column. In your text editor, position these annotations at column 73.
+    column. In your text editor, position these annotations at column **86**.
 
 **Example:**
 
 <pre><code>~~~~~
 DecodeHeader() {
-  draco_string                                                          UI8[5]
-  major_version                                                         UI8
-  minor_version                                                         UI8
-  encoder_type                                                          UI8
-  encoder_method                                                        UI8
+  draco_string                                                                       UI8[5]
+  major_version                                                                      UI8
+  minor_version                                                                      UI8
+  encoder_type                                                                       UI8
+  encoder_method                                                                     UI8
   flags
 }
 ~~~~~
@@ -210,11 +210,11 @@ DecodeHeader() {
 
 ~~~~~
 DecodeHeader() {
-  draco_string                                                          UI8[5]
-  major_version                                                         UI8
-  minor_version                                                         UI8
-  encoder_type                                                          UI8
-  encoder_method                                                        UI8
+  draco_string                                                                       UI8[5]
+  major_version                                                                      UI8
+  minor_version                                                                      UI8
+  encoder_type                                                                       UI8
+  encoder_method                                                                     UI8
   flags
 }
 ~~~~~

--- a/docs/spec/attributes.decoder.md
+++ b/docs/spec/attributes.decoder.md
@@ -5,14 +5,14 @@
 
 ~~~~~
 DecodeAttributesDecoderData(buffer) {
-  num_attributes                                                        varUI32
+  num_attributes                                                                     varUI32
   point_attribute_ids_.resize(num_attributes);
   for (i = 0; i < num_attributes; ++i) {
-    att_type                                                            UI8
-    data_type                                                           UI8
-    components_count                                                    UI8
-    normalized                                                          UI8
-    custom_id                                                           UI16
+    att_type                                                                         UI8
+    data_type                                                                        UI8
+    components_count                                                                 UI8
+    normalized                                                                       UI8
+    custom_id                                                                        UI16
     Initialize GeometryAttribute ga
     att_id = pc->AddAttribute(new PointAttribute(ga));
     point_attribute_ids_[i] = att_id;

--- a/docs/spec/core.functions.md
+++ b/docs/spec/core.functions.md
@@ -6,7 +6,7 @@
 ~~~~~
 DecodeVarint<IT>() {
   If (std::is_unsigned<IT>::value) {
-    in                                                                  UI8
+    in                                                                               UI8
     If (in & (1 << 7)) {
       out = DecodeVarint<IT>()
       out = (out << 7) | (in & ((1 << 7) - 1))
@@ -45,19 +45,19 @@ FIXME: ^^^ Heading level?
 
 ~~~~~
 decode_connectivity() {
-  num_faces                                                             I32
-  num_points                                                            I32
-  connectivity _method                                                  UI8
+  num_faces                                                                          I32
+  num_points                                                                         I32
+  connectivity _method                                                               UI8
   If (connectivity _method == 0) {
     // TODO
   } else {
     loop num_faces {
       If (num_points < 256) {
-        face[]                                                          UI8
+        face[]                                                                       UI8
       } else if (num_points < (1 << 16)) {
-        face[]                                                          UI16
+        face[]                                                                       UI16
       } else {
-        face[]                                                          UI32
+        face[]                                                                       UI32
       }
     }
   }

--- a/docs/spec/draco.decoder.md
+++ b/docs/spec/draco.decoder.md
@@ -18,11 +18,11 @@ Decode() {
 
 ~~~~~
 DecodeHeader() {
-  draco_string                                                          UI8[5]
-  major_version                                                         UI8
-  minor_version                                                         UI8
-  encoder_type                                                          UI8
-  encoder_method                                                        UI8
+  draco_string                                                                       UI8[5]
+  major_version                                                                      UI8
+  minor_version                                                                      UI8
+  encoder_type                                                                       UI8
+  encoder_method                                                                     UI8
   flags
 }
 ~~~~~
@@ -33,7 +33,7 @@ DecodeHeader() {
 
 ~~~~~
 DecodeAttributeData() {
-  num_attributes_decoders                                               UI8
+  num_attributes_decoders                                                            UI8
   for (i = 0; i < num_attributes_decoders; ++i) {
     CreateAttributesDecoder(i);
   }

--- a/docs/spec/edgebreaker.decoder.md
+++ b/docs/spec/edgebreaker.decoder.md
@@ -4,14 +4,14 @@
 
 ~~~~~
 DecodeConnectivityData() {
-  edgebreaker_traversal_type                                            UI8
-  num_new_verts                                                         varUI32
-  num_encoded_vertices                                                  varUI32
-  num_faces                                                             varUI32
-  num_attribute_data                                                    I8
-  num_encoded_symbols                                                   varUI32
-  num_encoded_split_symbols                                             varUI32
-  encoded_connectivity_size                                             varUI32
+  edgebreaker_traversal_type                                                         UI8
+  num_new_verts                                                                      varUI32
+  num_encoded_vertices                                                               varUI32
+  num_faces                                                                          varUI32
+  num_attribute_data                                                                 I8
+  num_encoded_symbols                                                                varUI32
+  num_encoded_split_symbols                                                          varUI32
+  encoded_connectivity_size                                                          varUI32
   // file pointer must be set to current position
   // + encoded_connectivity_size
   hole_and_split_bytes = DecodeHoleAndTopologySplitEvents()

--- a/docs/spec/edgebreaker.hole.and.topology.md
+++ b/docs/spec/edgebreaker.hole.and.topology.md
@@ -6,22 +6,22 @@
 
 ~~~~~
 DecodeHoleAndTopologySplitEvents() {
-  num_topologoy_splits                                                  varUI32
+  num_topologoy_splits                                                               varUI32
   source_symbol_id = 0
   for (i = 0; i < num_topologoy_splits; ++i) {
-    delta                                                               varUI32
+    delta                                                                            varUI32
     split_data[i].source_symbol_id = delta + source_symbol_id
-    delta                                                               varUI32
+    delta                                                                            varUI32
     split_data[i].split_symbol_id = source_symbol_id - delta
   }
   for (i = 0; i < num_topologoy_splits; ++i) {
-    split_data[i].split_edge                                            bits1
-    split_data[i].source_edge                                           bits1
+    split_data[i].split_edge                                                         bits1
+    split_data[i].source_edge                                                        bits1
   }
-  num_hole_events                                                       varUI32
+  num_hole_events                                                                    varUI32
   symbol_id = 0
   for (i = 0; i < num_hole_events; ++i) {
-    delta                                                               varUI32
+    delta                                                                            varUI32
     hole_data[i].symbol_id = delta + symbol_id
   }
   return bytes_decoded;
@@ -34,12 +34,12 @@ DecodeHoleAndTopologySplitEvents() {
 
 ~~~~~
 CreateAttributesDecoder() {
-  att_data_id                                                           I8
-  decoder_type                                                          UI8
+  att_data_id                                                                        I8
+  decoder_type                                                                       UI8
   if (att_data_id >= 0) {
     attribute_data_[att_data_id].decoder_id = att_decoder_id;
   }
-  traversal_method_encoded                                              UI8
+  traversal_method_encoded                                                           UI8
   if (decoder_type == MESH_VERTEX_ATTRIBUTE) {
     if (att_data_id < 0) {
       encoding_data = &pos_encoding_data_;

--- a/docs/spec/edgebreaker.traversal.decoder.md
+++ b/docs/spec/edgebreaker.traversal.decoder.md
@@ -5,10 +5,10 @@
 
 ~~~~~
 EdgebreakerTraversal_Start() {
-  size                                                                  UI64
-  symbol_buffer_                                                        size * UI8
-  size                                                                  UI64
-  start_face_buffer_                                                    size * UI8
+  size                                                                               UI64
+  symbol_buffer_                                                                     size * UI8
+  size                                                                               UI64
+  start_face_buffer_                                                                 size * UI8
   if (num_attribute_data > 0) {
     attribute_connectivity_decoders_ =
         new BinaryDecoder[num_attribute_data]
@@ -25,9 +25,9 @@ EdgebreakerTraversal_Start() {
 
 ~~~~~
 Traversal_DecodeSymbol() {
-  symbol_buffer_.DecodeLeastSignificantBits32(1, &symbol);              bits1
+  symbol_buffer_.DecodeLeastSignificantBits32(1, &symbol);                           bits1
   if (symbol != TOPOLOGY_C) {
-    symbol_buffer_.DecodeLeastSignificantBits32(2, &symbol_suffix);     bits2
+    symbol_buffer_.DecodeLeastSignificantBits32(2, &symbol_suffix);                  bits2
     symbol |= (symbol_suffix << 1);
   }
   return symbol

--- a/docs/spec/edgebreaker.traversal.valence.decoder.md
+++ b/docs/spec/edgebreaker.traversal.valence.decoder.md
@@ -6,15 +6,15 @@
 ~~~~~
 EdgeBreakerTraversalValence_Start(traversal_num_vertices) {
   EdgebreakerTraversal_Start()
-  num_split_symbols                                                     varUI32
-  mode == 0                                                             I8
+  num_split_symbols                                                                  varUI32
+  mode == 0                                                                          I8
   traversal_num_vertices += num_split_symbols
   vertex_valences_ init to 0
   min_valence_ = 2;
   max_valence_ = 7;
   num_unique_valences = 6 (max_valence_ - min_valence_ + 1)
   for (i = 0; i < num_unique_valences; ++i) {
-    num_symbols                                                         varUI32
+    num_symbols                                                                      varUI32
     if (num_symbols > 0) {
       DecodeSymbols(num_symbols, context_symbols_[i])
     }

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,5 +1,5 @@
 ---
-layout: spec
+layout: spec-page
 title: Draco Bitstream Specification (Draft)
 version: Version 1,2
 version_date: Released 2017-xx-xx

--- a/docs/spec/metadata.decoder.md
+++ b/docs/spec/metadata.decoder.md
@@ -4,9 +4,9 @@
 
 ~~~~~
 DecodeGeometryMetadata(metadata) {
-  num_att_metadata                                                      varUI32
+  num_att_metadata                                                                   varUI32
   for (i = 0; i < num_att_metadata; ++i) {
-    att_id                                                              varUI32
+    att_id                                                                           varUI32
     att_metadata = new AttributeMetadata(att_id)
     DecodeMetadata(att_metadata)
     metadata.att_metadata.push_back(att_metadata)
@@ -21,14 +21,14 @@ DecodeGeometryMetadata(metadata) {
 
 ~~~~~
 DecodeMetadata(metadata) {
-  num_entries                                                           varUI32
+  num_entries                                                                        varUI32
   for (i = 0; i < num_entries; ++i) {
     DecodeEntry(metadata)
   }
-  num_sub_metadata                                                      varUI32
+  num_sub_metadata                                                                   varUI32
   for (i = 0; i < num_sub_metadata; ++i) {
-    size                                                                UI8
-    name                                                                size * UI8
+    size                                                                             UI8
+    name                                                                             size * UI8
     temp_metadata = new Metadata()
     DecodeMetadata(temp_metadata)
     metadata.sub_metadata[name] = temp_metadata
@@ -42,10 +42,10 @@ DecodeMetadata(metadata) {
 
 ~~~~~
 DecodeEntry(metadata) {
-  size                                                                  UI8
-  name                                                                  size * UI8
-  size                                                                  varUI32
-  value                                                                 size * UI8
+  size                                                                               UI8
+  name                                                                               size * UI8
+  size                                                                               varUI32
+  value                                                                              size * UI8
   metadata.entries.insert(name, value)
 }
 ~~~~~

--- a/docs/spec/prediction.scheme.wrap.transform.md
+++ b/docs/spec/prediction.scheme.wrap.transform.md
@@ -5,8 +5,8 @@
 
 ~~~~~
 DecodeTransformData(buffer) {
-  min_value_                                                            DT
-  max_value_                                                            DT
+  min_value_                                                                         DT
+  max_value_                                                                         DT
 }
 ~~~~~
 {:.draco-syntax }

--- a/docs/spec/rans.bit.decoder.md
+++ b/docs/spec/rans.bit.decoder.md
@@ -5,9 +5,9 @@
 
 ~~~~~
 RansBitDecoder_StartDecoding() {
-  prob_zero_                                                            UI8
-  size                                                                  UI32
-  buffer_                                                               size * UI8
+  prob_zero_                                                                         UI8
+  size                                                                               UI32
+  buffer_                                                                            size * UI8
   ans_read_init(ans_decoder_, buffer_, size)
 }
 ~~~~~

--- a/docs/spec/sequential.attribute.decoder.md
+++ b/docs/spec/sequential.attribute.decoder.md
@@ -18,7 +18,7 @@ DecodeValues(const std::vector<PointIndex> &point_ids) {
   std::unique_ptr<uint8_t[]> value_data_ptr(new uint8_t[entry_size]);
   out_byte_pos = 0;
   for (i = 0; i < num_values; ++i) {
-   value_data                                                           UI8 * entry_size
+   value_data                                                                        UI8 * entry_size
     attribute_->buffer()->Write(out_byte_pos, value_data, entry_size);
     out_byte_pos += entry_size;
   }

--- a/docs/spec/sequential.attributes.decoders.controller.md
+++ b/docs/spec/sequential.attributes.decoders.controller.md
@@ -8,7 +8,7 @@ DecodeAttributesDecoderData(buffer) {
   AttributesDecoder_DecodeAttributesDecoderData(buffer)
   sequential_decoders_.resize(num_attributes());
   for (i = 0; i < num_attributes(); ++i) {
-    decoder_type                                                        UI8
+    decoder_type                                                                     UI8
     sequential_decoders_[i] = CreateSequentialDecoder(decoder_type);
     sequential_decoders_[i]->Initialize(decoder(), GetAttributeId(i))
 }

--- a/docs/spec/sequential.integer.attribute.decoder.md
+++ b/docs/spec/sequential.integer.attribute.decoder.md
@@ -13,9 +13,9 @@ Initialize(...) {
 
 ~~~~~
 DecodeValues(point_ids) {
-  prediction_scheme_method                                              I8
+  prediction_scheme_method                                                           I8
   if (prediction_scheme_method != PREDICTION_NONE) {
-    prediction_transform_type                                           I8
+    prediction_transform_type                                                        I8
     prediction_scheme_ = CreateIntPredictionScheme(...)
   }
   if (prediction_scheme_) {
@@ -33,7 +33,7 @@ DecodeValues(point_ids) {
 
 ~~~~~
 DecodeIntegerValues(point_ids) {
-  compressed                                                            UI8
+  compressed                                                                         UI8
   if (compressed) {
     DecodeSymbols(..., values_.data())
   } else {

--- a/docs/spec/sequential.quantization.attribute.decoder.md
+++ b/docs/spec/sequential.quantization.attribute.decoder.md
@@ -17,10 +17,10 @@ DecodeIntegerValues(point_ids) {
   // DecodeQuantizedDataInfo()
   num_components = attribute()->components_count();
   for (i = 0; i < num_components; ++i) {
-    min_value_[i]                                                       F32
+    min_value_[i]                                                                    F32
   }
-  max_value_dif_                                                        F32
-  quantization_bits_                                                    UI8
+  max_value_dif_                                                                     F32
+  quantization_bits_                                                                 UI8
   // REMOVE < DRACO_BITSTREAM_VERSION(2, 0)
   SequentialIntegerAttributeDecoder::DecodeIntegerValues()
 }

--- a/docs/spec/symbol.decoding.md
+++ b/docs/spec/symbol.decoding.md
@@ -5,7 +5,7 @@
 
 ~~~~~
 DecodeSymbols(num_symbols, out_values) {
-  scheme                                                                UI8
+  scheme                                                                             UI8
   If (scheme == 0) {
     DecodeTaggedSymbols(num_symbols, out_values)
   } else if (scheme == 1) {
@@ -30,7 +30,7 @@ DecodeTaggedSymbols() {
 
 ~~~~~
 DecodeRawSymbols(num_values, out_values) {
-  max_bit_length                                                        UI8
+  max_bit_length                                                                     UI8
   decoder = CreateRansSymbolDecoder(max_bit_length)
   decoder.StartDecoding()
   // RansSymbolDecoder_StartDecoding
@@ -52,9 +52,9 @@ CreateRansSymbolDecoder(max_bit_length) {
   rans_precision_bits = max(rans_precision_bits, 12)
   rans_precision = 1 << rans_precision_bits_;
   l_rans_base = rans_precision * 4;
-  num_symbols_                                                          UI32
+  num_symbols_                                                                       UI32
   for (i = 0; i < num_symbols_; ++i) {
-    prob_data                                                           UI8
+    prob_data                                                                        UI8
     if ((prob_data & 3) == 3) {
       offset = prob_data >> 2
       for (j = 0; j < offset + 1; ++j) {
@@ -64,7 +64,7 @@ CreateRansSymbolDecoder(max_bit_length) {
     } else {
       prob = prob_data >> 2
       for (j = 0; j < token; ++j) {
-        eb                                                              UI8
+        eb                                                                           UI8
         prob = prob | (eb << (8 * (j + 1) - 2)
       }
       probability_table_[i] = prob;
@@ -80,8 +80,8 @@ CreateRansSymbolDecoder(max_bit_length) {
 
 ~~~~~
 RansSymbolDecoder_StartDecoding() {
-  bytes_encoded                                                         UI64
-  buffer                                                                bytes_encoded * UI8
+  bytes_encoded                                                                      UI64
+  buffer                                                                             bytes_encoded * UI8
   rans_read_init(buffer, bytes_encoded)
 }
 ~~~~~


### PR DESCRIPTION
  * Create template for spec pages
  * Adapt syntax-table styles to Bootstrap
  * Reposition type/size annotations at col 86 (and update README.md)
  * Let Bootstrap style breadcrumb trails
  * Unrelated: abstract footer to an _include