### PR TITLE
Make spec table of contents collapsible.

### DIFF
--- a/docs/spec/00.00.05.toc.md
+++ b/docs/spec/00.00.05.toc.md
@@ -1,4 +1,8 @@
-**Contents**
+<a class="btn btn-primary" role="button" data-toggle="collapse" href="#contents" aria-expanded="false" aria-controls="contents">Contents</a>
+
+<div id="contents" class="collapse" markdown="1">
 
 * TOC
 {:toc}
+
+</div>


### PR DESCRIPTION
Spec's TOC is very long. This adds a button to toggle collapse-reveal
of TOC. Initially collapsed.