### PR TITLE
Simplify Node.js usage example.

### DIFF
--- a/javascript/npm/draco3d/README.md
+++ b/javascript/npm/draco3d/README.md
@@ -63,7 +63,7 @@ $ npm install draco3d
 ~~~~~ bash
 $ cp node_modules/draco3d/draco_nodejs_example.js .
 $ cp node_modules/draco3d/bunny.drc .
-$ nodejs draco_nodejs_example.js
+$ node draco_nodejs_example.js
 ~~~~~
 
 The code loads the [Bunny] model, it will first decode to a mesh

--- a/javascript/npm/draco3d/draco_nodejs_example.js
+++ b/javascript/npm/draco3d/draco_nodejs_example.js
@@ -89,7 +89,7 @@ function encodeMeshToFile(mesh, decoder) {
     const stride = attrs[attr];
     const numItems = numPoints * stride;
     const decoderAttr = decoderModule[attr];
-    const encoderAttr = decoderModule[attr];
+    const encoderAttr = encoderModule[attr];
     const attrId = decoder.GetAttributeId(mesh, decoderAttr);
 
     if (attrId < 0) {

--- a/javascript/npm/draco3d/draco_nodejs_example.js
+++ b/javascript/npm/draco3d/draco_nodejs_example.js
@@ -15,6 +15,7 @@
 'use_strict';
 
 const fs = require('fs');
+const assert = require('assert');
 const draco3d = require('./draco3d');
 const decoderModule = draco3d.createDecoderModule({});
 const encoderModule = draco3d.createEncoderModule({});
@@ -26,7 +27,7 @@ fs.readFile('./bunny.drc', function(err, data) {
   console.log("Decoding file of size " + data.byteLength + " ..");
   // Decode mesh
   const decoder = new decoderModule.Decoder();
-  let decodedGeometry = decodeDracoData(data, decoder);
+  const decodedGeometry = decodeDracoData(data, decoder);
   // Encode mesh
   encodeMeshToFile(decodedGeometry, decoder);
 
@@ -68,7 +69,7 @@ function encodeMeshToFile(mesh, decoder) {
   const numVertexCoord = numPoints * 3;
   console.log("Number of faces " + numFaces);
   console.log("Number of vertices " + numPoints);
-  let indices = new Uint32Array(numIndices);
+  const indices = new Uint32Array(numIndices);
 
   // Add Faces to mesh
   const ia = new decoderModule.DracoInt32Array();
@@ -82,81 +83,36 @@ function encodeMeshToFile(mesh, decoder) {
   decoderModule.destroy(ia);
   meshBuilder.AddFacesToMesh(newMesh, numFaces, indices);
 
-  // Add position data to mesh.
-  const posAttId = decoder.GetAttributeId(mesh, decoderModule.POSITION);
-  if (posAttId === -1) {
-    console.log("No position attribute found.");
-    encoderModule.destroy(newMesh);
-    encoderModule.destroy(encoder);
-    return;
-  }
-  const posAttribute = decoder.GetAttribute(mesh, posAttId);
-  const posAttributeData = new decoderModule.DracoFloat32Array();
-  decoder.GetAttributeFloatForAllPoints(
-      mesh, posAttribute, posAttributeData);
-  let vertices = new Float32Array(numVertexCoord);
-  for (let i = 0; i < numVertexCoord; i += 3) {
-    vertices[i] = posAttributeData.GetValue(i);
-    vertices[i + 1] = posAttributeData.GetValue(i + 1);
-    vertices[i + 2] = posAttributeData.GetValue(i + 2);
-  }
-  decoderModule.destroy(posAttributeData);
-  meshBuilder.AddFloatAttributeToMesh(newMesh, encoderModule.POSITION,
-                                      numPoints, 3, vertices);
+  const attrs = ["POSITION", "NORMAL", "TEX_COORD", "COLOR"];
 
-  const normalAttId = decoder.GetAttributeId(mesh, decoderModule.NORMAL);
-  if (normalAttId > -1) {
-    console.log("Adding normal attribute.");
-    const norAttribute = decoder.GetAttribute(mesh, normalAttId);
-    const norAttributeData = new decoderModule.DracoFloat32Array();
-    decoder.GetAttributeFloatForAllPoints(mesh, norAttribute,
-        norAttributeData);
-    const normals = new Float32Array(numVertexCoord);
-    for (let i = 0; i < numVertexCoord; i += 3) {
-      normals[i] = norAttributeData.GetValue(i);
-      normals[i + 1] = norAttributeData.GetValue(i + 1);
-      normals[i + 2] = norAttributeData.GetValue(i + 2);
-    }
-    decoderModule.destroy(norAttributeData);
-    meshBuilder.AddFloatAttributeToMesh(newMesh, encoderModule.NORMAL,
-        numPoints, 3, normals);
-  }
+  attrs.forEach((attr) => {
+    const decoderAttr = decoderModule[attr];
+    const encoderAttr = decoderModule[attr];
+    const attrId = decoder.GetAttributeId(mesh, decoderAttr);
 
-  const texAttId = decoder.GetAttributeId(mesh, decoderModule.TEX_COORD);
-  if (texAttId > -1) {
-    const texAttribute = decoder.GetAttribute(mesh, texAttId);
-    const texAttributeData = new decoderModule.DracoFloat32Array();
-    decoder.GetAttributeFloatForAllPoints(mesh, texAttribute,
-        texAttributeData);
-    assertEquals(numVertexCoord, texAttributeData.size());
-    const texcoords = new Float32Array(numVertexCoord);
-    for (let i = 0; i < numVertexCoord; i += 3) {
-      texcoords[i] = texAttributeData.GetValue(i);
-      texcoords[i + 1] = texAttributeData.GetValue(i + 1);
-      texcoords[i + 2] = texAttributeData.GetValue(i + 2);
+    if (attrId < 0) {
+      return;
     }
-    decoderModule.destroy(texAttributeData);
-    meshBuilder.AddFloatAttributeToMesh(newMesh, encoderModule.TEX_COORD,
-        numPoints, 3, normals);
-  }
 
-  const colorAttId = decoder.GetAttributeId(mesh, decoderModule.COLOR);
-  if (colorAttId > -1) {
-    const colAttribute = decoder.GetAttribute(mesh, colorAttId);
-    const colAttributeData = new decoderModule.DracoFloat32Array();
-    decoder.GetAttributeFloatForAllPoints(mesh, colAttribute,
-        colAttributeData);
-    assertEquals(numVertexCoord, colAttributeData.size());
-    const colors = new Float32Array(numVertexCoord);
+    console.log("Adding %s attribute", attr);
+
+    const attribute = decoder.GetAttribute(mesh, attrId);
+    const attributeData = new decoderModule.DracoFloat32Array();
+    decoder.GetAttributeFloatForAllPoints(mesh, attribute, attributeData);
+
+    assert(numVertexCoord === attributeData.size(), 'Wrong attribute size.');
+
+    const attributeDataArray = new Float32Array(numVertexCoord);
     for (let i = 0; i < numVertexCoord; i += 3) {
-      colors[i] = colAttributeData.GetValue(i);
-      colors[i + 1] = colAttributeData.GetValue(i + 1);
-      colors[i + 2] = colAttributeData.GetValue(i + 2);
+      attributeDataArray[i] = attributeData.GetValue(i);
+      attributeDataArray[i + 1] = attributeData.GetValue(i + 1);
+      attributeDataArray[i + 2] = attributeData.GetValue(i + 2);
     }
-    decoderModule.destroy(colAttributeData);
-    meshBuilder.AddFloatAttributeToMesh(newMesh, encoderModule.COLOR,
-        numPoints, 3, normals);
-  }
+
+    decoderModule.destroy(attributeData);
+    meshBuilder.AddFloatAttributeToMesh(newMesh, encoderAttr, numPoints, 3,
+        attributeDataArray);
+  });
 
   let encodedData = new encoderModule.DracoInt8Array();
   // Set encoding options.
@@ -176,8 +132,8 @@ function encodeMeshToFile(mesh, decoder) {
     console.log("Error: Encoding failed.");
   }
   // Copy encoded data to buffer.
-  let outputBuffer = new ArrayBuffer(encodedLen);
-  let outputData = new Int8Array(outputBuffer);
+  const outputBuffer = new ArrayBuffer(encodedLen);
+  const outputData = new Int8Array(outputBuffer);
   for (let i = 0; i < encodedLen; ++i) {
     outputData[i] = encodedData.GetValue(i);
   }
@@ -187,7 +143,7 @@ function encodeMeshToFile(mesh, decoder) {
   // Write to file. You can view the the file using webgl_loader_draco.html
   // example.
   fs.writeFile("bunny_10.drc", Buffer(outputBuffer), "binary", function(err) {
-    if(err) {
+    if (err) {
         console.log(err);
     } else {
         console.log("The file was saved!");

--- a/javascript/npm/draco3d/draco_nodejs_example.js
+++ b/javascript/npm/draco3d/draco_nodejs_example.js
@@ -87,7 +87,7 @@ function encodeMeshToFile(mesh, decoder) {
 
   Object.keys(attrs).forEach((attr) => {
     const stride = attrs[attr];
-    const numItems = numPoints * stride;
+    const numValues = numPoints * stride;
     const decoderAttr = decoderModule[attr];
     const encoderAttr = encoderModule[attr];
     const attrId = decoder.GetAttributeId(mesh, decoderAttr);
@@ -102,13 +102,11 @@ function encodeMeshToFile(mesh, decoder) {
     const attributeData = new decoderModule.DracoFloat32Array();
     decoder.GetAttributeFloatForAllPoints(mesh, attribute, attributeData);
 
-    assert(numItems === attributeData.size(), 'Wrong attribute size.');
+    assert(numValues === attributeData.size(), 'Wrong attribute size.');
 
-    const attributeDataArray = new Float32Array(numItems);
-    for (let i = 0; i < numItems; i += stride) {
-      for (let j = 0; j < stride; ++j) {
-        attributeDataArray[i + j] = attributeData.GetValue(i + j);
-      }
+    const attributeDataArray = new Float32Array(numValues);
+    for (let i = 0; i < numValues; ++i) {
+      attributeDataArray[i] = attributeData.GetValue(i);
     }
 
     decoderModule.destroy(attributeData);

--- a/javascript/npm/draco3d/draco_nodejs_example.js
+++ b/javascript/npm/draco3d/draco_nodejs_example.js
@@ -66,7 +66,6 @@ function encodeMeshToFile(mesh, decoder) {
   const numFaces = mesh.num_faces();
   const numIndices = numFaces * 3;
   const numPoints = mesh.num_points();
-  const numVertexCoord = numPoints * 3;
   const indices = new Uint32Array(numIndices);
 
   console.log("Number of faces " + numFaces);
@@ -88,6 +87,7 @@ function encodeMeshToFile(mesh, decoder) {
 
   Object.keys(attrs).forEach((attr) => {
     const stride = attrs[attr];
+    const numItems = numPoints * stride;
     const decoderAttr = decoderModule[attr];
     const encoderAttr = decoderModule[attr];
     const attrId = decoder.GetAttributeId(mesh, decoderAttr);
@@ -102,10 +102,10 @@ function encodeMeshToFile(mesh, decoder) {
     const attributeData = new decoderModule.DracoFloat32Array();
     decoder.GetAttributeFloatForAllPoints(mesh, attribute, attributeData);
 
-    assert(numVertexCoord === attributeData.size(), 'Wrong attribute size.');
+    assert(numItems === attributeData.size(), 'Wrong attribute size.');
 
-    const attributeDataArray = new Float32Array(numVertexCoord);
-    for (let i = 0; i < numVertexCoord; i += stride) {
+    const attributeDataArray = new Float32Array(numItems);
+    for (let i = 0; i < numItems; i += stride) {
       for (let j = 0; j < stride; ++j) {
         attributeDataArray[i + j] = attributeData.GetValue(i + j);
       }

--- a/javascript/npm/draco3d/package.json
+++ b/javascript/npm/draco3d/package.json
@@ -13,5 +13,9 @@
     "point cloud"
   ],
   "author": "Google Draco Team",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/google/draco.git"
+  }
 }


### PR DESCRIPTION
Couple small changes here:

- Replace `nodejs` with more common `node` executable name.
- Add GitHub URL to npm package, so cross-link will appear on [package description](https://www.npmjs.com/package/draco3d).
- Simplify example script a bit, reusing code shared among attributes, and fixing a couple let/const issues.