### PR TITLE
npm: fixed npm example

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,8 +387,8 @@ if (geom_type == draco::TRIANGULAR_MESH) {
 }
 ~~~~~
 
-Please see `mesh/mesh.h` for the full Mesh class interface and
-`point_cloud/point_cloud.h` for the full `PointCloud` class interface.
+Please see [src/draco/mesh/mesh.h](src/draco/mesh/mesh.h) for the full Mesh class interface and
+[src/draco/point_cloud/point_cloud.h](src/draco/point_cloud/point_cloud.h) for the full `PointCloud` class interface.
 
 
 Javascript Encoder API
@@ -450,12 +450,12 @@ encoderModule.destroy(encoder);
 encoderModule.destroy(meshBuilder);
 
 ~~~~~
-Please see `javascript/emscripten/draco_web_encoder.idl` for the full API.
+Please see [src/draco/javascript/emscripten/draco_web_encoder.idl](src/draco/javascript/emscripten/draco_web_encoder.idl) for the full API.
 
 Javascript Decoder API
 ----------------------
 
-The Javascript decoder is located in `javascript/draco_decoder.js`. The
+The Javascript decoder is located in [javascript/draco_decoder.js](javascript/draco_decoder.js). The
 Javascript decoder can decode mesh and point cloud. In order to use the
 decoder, you must first create an instance of `DracoDecoderModule`. The
 instance is then used to create `DecoderBuffer` and `Decoder` objects. Set
@@ -484,7 +484,7 @@ dracoDecoder.destroy(decoder);
 dracoDecoder.destroy(buffer);
 ~~~~~
 
-Please see `javascript/emscripten/draco_web_decoder.idl` for the full API.
+Please see [src/draco/javascript/emscripten/draco_web_encoder.idl](src/draco/javascript/emscripten/draco_web_encoder.idl) for the full API.
 
 Javascript Decoder Performance
 ------------------------------
@@ -546,11 +546,11 @@ const draco::AttributeMetadata *pos_metadata =
   pc_metadata->GetAttributeMetadata(pos_att_id);
 ~~~~~
 
-Please see `src/draco/metadata` and `src/draco/point_cloud` for the full API.
+Please see [src/draco/metadata](src/draco/metadata) and [src/draco/point_cloud](src/draco/point_cloud) for the full API.
 
 NPM Package
 -----------
-Draco NPM NodeJS package is located in `javascript/npm/draco3d`. Please see the
+Draco NPM NodeJS package is located in [javascript/npm/draco3d](javascript/npm/draco3d). Please see the
 doc in the folder for detailed usage.
 
 three.js Renderer Example
@@ -559,7 +559,7 @@ three.js Renderer Example
 Here's an [example] of a geometric compressed with Draco loaded via a
 Javascript decoder using the `three.js` renderer.
 
-Please see the `javascript/example/README` file for more information.
+Please see the [javascript/example/README](javascript/example/README) file for more information.
 
 Support
 =======
@@ -592,6 +592,6 @@ References
 [meshes]: https://en.wikipedia.org/wiki/Polygon_mesh
 [point clouds]: https://en.wikipedia.org/wiki/Point_cloud
 [Bunny]: https://graphics.stanford.edu/data/3Dscanrep/
-[CONTRIBUTING]: https://raw.githubusercontent.com/google/draco/master/CONTRIBUTING
+[CONTRIBUTING]: https://raw.githubusercontent.com/google/draco/master/CONTRIBUTING.md
 
 Bunny model from Stanford's graphic department <https://graphics.stanford.edu/data/3Dscanrep/>

--- a/javascript/npm/draco3d/draco_nodejs_example.js
+++ b/javascript/npm/draco3d/draco_nodejs_example.js
@@ -16,7 +16,7 @@
 
 const fs = require('fs');
 const assert = require('assert');
-const draco3d = require('./draco3d');
+const draco3d = fs.existsSync('./draco3d') ? require('./draco3d') : require('draco3d');
 const decoderModule = draco3d.createDecoderModule({});
 const encoderModule = draco3d.createEncoderModule({});
 

--- a/javascript/npm/draco3d/draco_nodejs_example.js
+++ b/javascript/npm/draco3d/draco_nodejs_example.js
@@ -16,7 +16,7 @@
 
 const fs = require('fs');
 const assert = require('assert');
-const draco3d = fs.existsSync('./draco3d') ? require('./draco3d') : require('draco3d');
+const draco3d = require('draco3d');
 const decoderModule = draco3d.createDecoderModule({});
 const encoderModule = draco3d.createEncoderModule({});
 


### PR DESCRIPTION
Allows draco3d to be called from same directory or npm package

If you follow the [instructions on NPM readme](https://github.com/google/draco/blob/master/javascript/npm/draco3d/README.md#npm-package) you will find you need to edit the file because `./draco3d` is not a file when you copy it out of the `node_module` file with `cp node_modules/draco3d/draco_nodejs_example.js .`

This seems like the simpler solution than adding an instruction to open the file in a text editor and fix it