### PR TITLE
Added handling for all enum in draco::DataType

### DIFF
--- a/src/draco/attributes/geometry_attribute.h
+++ b/src/draco/attributes/geometry_attribute.h
@@ -112,28 +112,40 @@ class GeometryAttribute {
     if (out_val == nullptr)
       return false;
     switch (data_type_) {
-      case DT_FLOAT32:
-        return ConvertTypedValue<float, OutT, out_att_components_t>(att_id,
-                                                                    out_val);
-      case DT_UINT8:
-        return ConvertTypedValue<uint8_t, OutT, out_att_components_t>(att_id,
-                                                                      out_val);
-      case DT_INT8:
+	  case DT_INT8:
         return ConvertTypedValue<int8_t, OutT, out_att_components_t>(att_id,
                                                                      out_val);
-      case DT_UINT16:
-        return ConvertTypedValue<uint16_t, OutT, out_att_components_t>(att_id,
-                                                                       out_val);
+	  case DT_UINT8:
+		  return ConvertTypedValue<uint8_t, OutT, out_att_components_t>(att_id,
+                                                                        out_val);
       case DT_INT16:
         return ConvertTypedValue<int16_t, OutT, out_att_components_t>(att_id,
                                                                       out_val);
-      case DT_UINT32:
-        return ConvertTypedValue<uint32_t, OutT, out_att_components_t>(att_id,
-                                                                       out_val);
+	  case DT_UINT16:
+		  return ConvertTypedValue<uint16_t, OutT, out_att_components_t>(att_id,
+                                                                         out_val);
       case DT_INT32:
         return ConvertTypedValue<int32_t, OutT, out_att_components_t>(att_id,
                                                                       out_val);
-      default:
+	  case DT_UINT32:
+		  return ConvertTypedValue<uint32_t, OutT, out_att_components_t>(att_id,
+                                                                         out_val);
+	  case DT_INT64:
+		  return ConvertTypedValue<int64_t, OutT, out_att_components_t>(att_id,
+                                                                        out_val);
+	  case DT_UINT64:
+		  return ConvertTypedValue<uint64_t, OutT, out_att_components_t>(att_id,
+                                                                         out_val);
+	  case DT_FLOAT32:
+		  return ConvertTypedValue<float, OutT, out_att_components_t>(att_id,
+                                                                      out_val);
+	  case DT_FLOAT64:
+		  return ConvertTypedValue<double, OutT, out_att_components_t>(att_id,
+                                                                       out_val);
+	  case DT_BOOL:
+		  return ConvertTypedValue<bool, OutT, out_att_components_t>(att_id,
+                                                                     out_val);
+	  default:
         // Wrong attribute type.
         return false;
     }


### PR DESCRIPTION
Added support for 64bit integer, 64bit float and boolean in
ConvertValue

I have also reordered the case statement so that it matches
the order in the draco::DataType enum for easier maintenance
