### PR TITLE
Add basic Travis-CI support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
-os:
-  - linux
-  - osx
-dist: trusty
-osx_image: xcode8.3
-language: cpp
-compiler:
-  - clang
-  - gcc
 cache: ccache
+language: cpp
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      compiler: clang
+    - os: linux
+      dist: trusty
+      compiler: gcc
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 os: linux
 dist: trusty
-sudo: require
 language: cpp
-compiler: gcc
+compiler:
+  - clang
+  - gcc
 cache: ccache
 
 addons:
@@ -10,20 +11,16 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - gcc-6
-    - g++-6
     - ccache
     - cmake
 
 script:
-  # Link gcc-6 and g++-6 to their standard commands
-  - ln -s /usr/bin/gcc-6 /usr/local/bin/gcc
-  - ln -s /usr/bin/g++-6 /usr/local/bin/g++
-  # Export CC and CXX to tell cmake which compiler to use
-  - export CC=/usr/bin/gcc-6
-  - export CXX=/usr/bin/g++-6
-  # Check versions of gcc, g++ and cmake
-  - gcc -v && g++ -v && cmake --version
+  # Output versions of gcc, g++ and cmake
+  - clang -v
+  - clang++ -v
+  - gcc -v
+  - g++ -v
+  - make --version
   # Configure and build
   - mkdir _travis_build && cd _travis_build
   - cmake -G "Unix Makefiles" -DENABLE_TESTING=ON -DENABLE_CCACHE=ON ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+dist: trusty
+sudo: require
+language: cpp
+compiler: gcc
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-6
+    - g++-6
+    - ccache
+    - cmake
+
+script:
+  # Link gcc-6 and g++-6 to their standard commands
+  - ln -s /usr/bin/gcc-6 /usr/local/bin/gcc
+  - ln -s /usr/bin/g++-6 /usr/local/bin/g++
+  # Export CC and CXX to tell cmake which compiler to use
+  - export CC=/usr/bin/gcc-6
+  - export CXX=/usr/bin/g++-6
+  # Check versions of gcc, g++ and cmake
+  - gcc -v && g++ -v && cmake --version
+  # Configure and build
+  - mkdir _travis_build && cd _travis_build
+  - cmake -G "Unix Makefiles" -DENABLE_TESTING=ON -DENABLE_CCACHE=ON ..
+  - make -j
+  - ./draco_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: trusty
 sudo: require
 language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,10 @@ addons:
     - cmake
 
 script:
-  # Output versions of gcc, g++ and cmake
-  - clang -v
-  - clang++ -v
-  - gcc -v
-  - g++ -v
+  # Output version info for compilers, cmake, and make
+  - ${CC} -v
+  - ${CXX} -v
+  - cmake --version
   - make --version
   # Configure and build
   - mkdir _travis_build && cd _travis_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
-os: linux
+os:
+  - linux
+  - osx
 dist: trusty
+osx_image: xcode8.3
 language: cpp
 compiler:
   - clang
@@ -13,6 +16,9 @@ addons:
     packages:
     - ccache
     - cmake
+
+before_install:
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew install ccache; fi
 
 script:
   # Output version info for compilers, cmake, and make

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ script:
   - ${CXX} -v
   - cmake --version
   - make --version
+  # Clone googletest
+  - pushd .. && git clone https://github.com/google/googletest.git && popd
   # Configure and build
   - mkdir _travis_build && cd _travis_build
   - cmake -G "Unix Makefiles" -DENABLE_TESTS=ON -DENABLE_CCACHE=ON ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ script:
   - make --version
   # Configure and build
   - mkdir _travis_build && cd _travis_build
-  - cmake -G "Unix Makefiles" -DENABLE_TESTING=ON -DENABLE_CCACHE=ON ..
+  - cmake -G "Unix Makefiles" -DENABLE_TESTS=ON -DENABLE_CCACHE=ON ..
   - make -j
   - ./draco_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: trusty
 sudo: require
 language: cpp
 compiler: gcc
+cache: ccache
 
 addons:
   apt:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.2)
 project(draco C CXX)
 
 set(draco_root "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
Builds and runs draco_tests on linux (clang and gcc) and osx (clang).