### PR TITLE
Spec: Remove split_edge from bitstream 2.2

### DIFF
--- a/docs/spec/edgebreaker.decoder.md
+++ b/docs/spec/edgebreaker.decoder.md
@@ -26,7 +26,6 @@ void ParseTopologySplitEvents() {
     split_id_delta[i]                                                                 varUI32
   }
   for (i = 0; i < num_topology_splits; ++i) {
-    split_edge_bit[i]                                                                 f[1]
     source_edge_bit[i]                                                                f[1]
   }
 }

--- a/docs/spec/variable.descriptions.md
+++ b/docs/spec/variable.descriptions.md
@@ -124,7 +124,6 @@
   * Array of delta encoded source symbol ids
 * split_id_delta
   * Array of delta encoded split symbol ids
-* split_edge_bit
 * source_edge_bit
   * Array of source edge types
   * 0: LEFT_FACE_EDGE


### PR DESCRIPTION
- The split_edge was removed from bitstream 2.2 as it was not used
  during decoding.