### PR TITLE
Spec: Change RansBitDecoder size to varUI32

### DIFF
--- a/docs/spec/edgebreaker.traversal.md
+++ b/docs/spec/edgebreaker.traversal.md
@@ -11,7 +11,7 @@ void ParseEdgebreakerTraversalStandardData() {
   eb_start_face_buffer                                                                size * UI8
   for (i = 0; i < num_attribute_data; ++i) {
     attribute_connectivity_decoders_prob_zero[i]                                      UI8
-    attribute_connectivity_decoders_size[i]                                           UI32
+    attribute_connectivity_decoders_size[i]                                           varUI32
     attribute_connectivity_decoders_buffer[i]                                         size * UI8
   }
 }

--- a/docs/spec/prediction.decoder.md
+++ b/docs/spec/prediction.decoder.md
@@ -90,7 +90,7 @@ void DecodeTransformData() {
 ~~~~~
 void ParsePredictionRansData() {
   prediction_rans_prob_zero                                                           UI8
-  prediction_rans_data_size                                                           UI32
+  prediction_rans_data_size                                                           varUI32
 }
 ~~~~~
 {:.draco-syntax}


### PR DESCRIPTION
- Bitstream 2.2 changed the RansBitCoder size from UI32 to varUI32.
- This is associated with KhronosGroup/glTF#1114