### PR TITLE
Spec: Remove symbol buffer from Valence EdgeBreaker

### DIFF
--- a/docs/spec/edgebreaker.traversal.md
+++ b/docs/spec/edgebreaker.traversal.md
@@ -1,20 +1,50 @@
 
 ## EdgeBreaker Traversal
 
-### ParseEdgebreakerTraversalStandardData()
+### ParseEdgebreakerTraversalStandardSymbolData()
 
 ~~~~~
-void ParseEdgebreakerTraversalStandardData() {
+void ParseEdgebreakerTraversalStandardSymbolData() {
   eb_symbol_buffer_size                                                               UI64
   eb_symbol_buffer                                                                    size * UI8
+}
+~~~~~
+{:.draco-syntax }
+
+
+### ParseEdgebreakerTraversalStandardFaceData()
+
+~~~~~
+void ParseEdgebreakerTraversalStandardFaceData() {
   eb_start_face_buffer_prob_zero                                                      UI8
   eb_start_face_buffer_size                                                           varUI32
   eb_start_face_buffer                                                                size * UI8
+}
+~~~~~
+{:.draco-syntax }
+
+
+### ParseEdgebreakerTraversalStandardAttributeConnectivityData()
+
+~~~~~
+void ParseEdgebreakerTraversalStandardAttributeConnectivityData() {
   for (i = 0; i < num_attribute_data; ++i) {
     attribute_connectivity_decoders_prob_zero[i]                                      UI8
     attribute_connectivity_decoders_size[i]                                           varUI32
     attribute_connectivity_decoders_buffer[i]                                         size * UI8
   }
+}
+~~~~~
+{:.draco-syntax }
+
+
+### DecodeEdgebreakerTraversalStandardData()
+
+~~~~~
+void DecodeEdgebreakerTraversalStandardData() {
+  ParseEdgebreakerTraversalStandardSymbolData()
+  ParseEdgebreakerTraversalStandardFaceData()
+  ParseEdgebreakerTraversalStandardAttributeConnectivityData()
 }
 ~~~~~
 {:.draco-syntax }
@@ -26,8 +56,9 @@ void ParseEdgebreakerTraversalStandardData() {
 void EdgebreakerTraversalStart() {
   last_symbol_ = -1;
   active_context_ = -1;
-  ParseEdgebreakerTraversalStandardData();
-  if (edgebreaker_traversal_type == VALENCE_EDGEBREAKER) {
+  if (edgebreaker_traversal_type == STANDARD_EDGEBREAKER) {
+    DecodeEdgebreakerTraversalStandardData();
+  } else if (edgebreaker_traversal_type == VALENCE_EDGEBREAKER) {
     EdgeBreakerTraversalValenceStart();
   }
 }

--- a/docs/spec/edgebreaker.traversal.valence.md
+++ b/docs/spec/edgebreaker.traversal.valence.md
@@ -16,6 +16,8 @@ void ParseValenceContextCounters(index) {
 
 ~~~~~
 void EdgeBreakerTraversalValenceStart() {
+  ParseEdgebreakerTraversalStandardFaceData()
+  ParseEdgebreakerTraversalStandardAttributeConnectivityData()
   vertex_valences_.assign(num_encoded_vertices + num_encoded_split_symbols, 0);
   for (i = 0; i < NUM_UNIQUE_VALENCES; ++i) {
     ParseValenceContextCounters(i);
@@ -38,7 +40,7 @@ void EdgebreakerValenceDecodeSymbol() {
                                    [--ebv_context_counters[active_context_]];
     last_symbol_ = edge_breaker_symbol_to_topology_id[symbol_id];
   } else {
-    ParseEdgebreakerStandardSymbol();
+    last_symbol_ = TOPOLOGY_E;
   }
 }
 ~~~~~


### PR DESCRIPTION
- This change is in bitstream 2.2.
- This is associated with KhronosGroup/glTF#1114