### PR TITLE
Spec: Change DirectBitCoder size to varUI64

### DIFF
--- a/docs/spec/edgebreaker.traversal.md
+++ b/docs/spec/edgebreaker.traversal.md
@@ -5,7 +5,7 @@
 
 ~~~~~
 void ParseEdgebreakerTraversalStandardSymbolData() {
-  eb_symbol_buffer_size                                                               UI64
+  eb_symbol_buffer_size                                                               varUI64
   eb_symbol_buffer                                                                    size * UI8
 }
 ~~~~~


### PR DESCRIPTION
- This change is in bitstream 2.2.
- This is associated with KhronosGroup/glTF#1114