### PR TITLE
Spec: Addressing comments

### DIFF
--- a/docs/spec/attributes.decoder.md
+++ b/docs/spec/attributes.decoder.md
@@ -128,7 +128,7 @@ void RecomputeVerticesInternal() {
 
 ~~~~~
 void Attribute_AssignPointsToCorners() {
-  num_corners = face_to_vertex[0].size() * 3;
+  point_to_corner_map_count = 0;
   for (v = 0; v < num_encoded_vertices + num_encoded_split_symbols; ++v) {
     c = vertex_corners_[v];
     if (c < 0)
@@ -159,8 +159,7 @@ void Attribute_AssignPointsToCorners() {
     }
 
     c = deduplication_first_corner;
-    corner_to_point_map[c] = point_to_corner_map.size();
-    point_to_corner_map.push_back(c);
+    corner_to_point_map[c] = point_to_corner_map_count++;
     prev_c = c;
     c = SwingRight(0, c);
     while (c >= 0 && c != deduplication_first_corner) {
@@ -174,8 +173,7 @@ void Attribute_AssignPointsToCorners() {
         }
       }
       if (attribute_seam) {
-        corner_to_point_map[c] = point_to_corner_map.size();
-        point_to_corner_map.push_back(c);
+        corner_to_point_map[c] = point_to_corner_map_count++;
       } else {
         corner_to_point_map[c] = corner_to_point_map[prev_c];
       }

--- a/docs/spec/boundary.decoder.md
+++ b/docs/spec/boundary.decoder.md
@@ -5,7 +5,6 @@
 ~~~~~
 void DecodeAttributeSeams() {
   for (a = 0; a < num_attributes_decoders - 1; ++a) {
-    AnsDecoder ans_decoder_;
     RansInitDecoder(ans_decoder_,
         attribute_connectivity_decoders_buffer[a],
         attribute_connectivity_decoders_size[a], L_RANS_BASE);
@@ -24,7 +23,7 @@ void DecodeAttributeSeams() {
       if (!boundary_edge) {
         if (opp_corner >= corner) {
           for (a = 0; a < num_attributes_decoders - 1; ++a) {
-            RabsDescRead(&ans_decoders[a],
+            RabsDescRead(ans_decoders[a],
                          attribute_connectivity_decoders_prob_zero[a], &val);
             if (val) {
               att_connectivity_seam_opp[a].push_back(v);

--- a/docs/spec/edgebreaker.decoder.md
+++ b/docs/spec/edgebreaker.decoder.md
@@ -5,7 +5,6 @@
 ~~~~~
 void ParseEdgebreakerConnectivityData() {
   edgebreaker_traversal_type                                                          UI8
-  num_new_vertices                                                                    varUI32
   num_encoded_vertices                                                                varUI32
   num_faces                                                                           varUI32
   num_attribute_data                                                                  UI8
@@ -354,6 +353,7 @@ void EdgebreakerDecodeSymbol() {
 ~~~~~
 void DecodeEdgeBreakerConnectivity() {
   is_vert_hole_.assign(num_encoded_vertices + num_encoded_split_symbols, true);
+  last_vert_added = -1;
   for (i = 0; i < num_encoded_symbols; ++i) {
     EdgebreakerDecodeSymbol();
     corner = 3 * i;
@@ -369,7 +369,6 @@ void DecodeEdgeBreakerConnectivity() {
 
 ~~~~~
 void ProcessInteriorEdges() {
-  AnsDecoder ans_decoder_;
   RansInitDecoder(ans_decoder_, eb_start_face_buffer,
       eb_start_face_buffer_size, L_RANS_BASE);
 

--- a/docs/spec/prediction.decoder.md
+++ b/docs/spec/prediction.decoder.md
@@ -92,7 +92,8 @@ void DecodeTransformData() {
 ~~~~~
 void ParsePredictionRansData() {
   prediction_rans_prob_zero                                                           UI8
-  prediction_rans_data_size                                                           varUI32
+  sz = prediction_rans_data_size                                                      varUI32
+  prediction_rans_data_buffer                                                         UI8[sz]
 }
 ~~~~~
 {:.draco-syntax}
@@ -116,10 +117,10 @@ void DecodePredictionData_ConstrainedMulti() {
     ParseConstrainedMultiNumFlags();
     if (constrained_multi_num_flags > 0) {
       ParsePredictionRansData();
-      RansInitDecoder(ans_decoder_, data + pos,
+      RansInitDecoder(ans_decoder_, prediction_rans_data_buffer,
                       prediction_rans_data_size, L_RANS_BASE);
       for (j = 0; j < constrained_multi_num_flags; ++j) {
-        RabsDescRead(&ans_decoder_, prediction_rans_prob_zero, &val);
+        RabsDescRead(ans_decoder_, prediction_rans_prob_zero, &val);
         is_crease_edge_[i][j] = val > 0;
       }
     }
@@ -146,16 +147,16 @@ void ParseTexCoordsNumOrientations() {
 void DecodePredictionData_TexCoords() {
   ParseTexCoordsNumOrientations();
   ParsePredictionRansData();
-  RansInitDecoder(ans_decoder_, data + pos,
+  RansInitDecoder(ans_decoder_, prediction_rans_data_buffer,
                   prediction_rans_data_size, L_RANS_BASE);
   last_orientation = true;
   for (i = 0; i < tex_coords_num_orientations; ++i) {
-    RabsDescRead(&ans_decoder_, prediction_rans_prob_zero, &val);
+    RabsDescRead(ans_decoder_, prediction_rans_prob_zero, &val);
     if (val == 0)
       last_orientation = !last_orientation;
-    orientaitons.push_back(last_orientation);
+    orientations.push_back(last_orientation);
   }
-  pred_tex_coords_orientaitons[curr_att_dec][curr_att] = orientaitons;
+  pred_tex_coords_orientations[curr_att_dec][curr_att] = orientations;
 }
 ~~~~~
 {:.draco-syntax}
@@ -166,11 +167,11 @@ void DecodePredictionData_TexCoords() {
 ~~~~~
 void DecodePredictionData_GeometricNormal() {
   ParsePredictionRansData();
-  RansInitDecoder(ans_decoder_, data + pos,
+  RansInitDecoder(ans_decoder_, prediction_rans_data_buffer,
                   prediction_rans_data_size, L_RANS_BASE);
   num_values = att_dec_num_values_to_decode[curr_att_dec][curr_att];
   for (i = 0; i < num_values; ++i) {
-    RabsDescRead(&ans_decoder_, prediction_rans_prob_zero, &val);
+    RabsDescRead(ans_decoder_, prediction_rans_prob_zero, &val);
     flip_normal_bits.push_back(val > 0);
   }
   pred_transform_normal_flip_normal_bits[curr_att_dec][curr_att] = flip_normal_bits;

--- a/docs/spec/prediction.normal.decoder.md
+++ b/docs/spec/prediction.normal.decoder.md
@@ -43,8 +43,8 @@ void MeshPredictionSchemeGeometricNormalPredictorArea_ComputePredictedValue(
     c_prev = Previous(corner);
     GetPositionForCorner(c_next, &pos_next);
     GetPositionForCorner(c_prev, &pos_prev);
-    SubtractInt64Vectors(pos_next, pos_cent, &delta_next);
-    SubtractInt64Vectors(pos_prev, pos_cent, &delta_prev);
+    SubtractVectors(pos_next, pos_cent, &delta_next);
+    SubtractVectors(pos_prev, pos_cent, &delta_prev);
     CrossProduct(delta_next, delta_prev, &cross);
     AddVectors(normal, cross, &temp_norm);
     for (i = 0; i < temp_norm.size(); ++i) {

--- a/docs/spec/prediction.parallelogram.decoder.md
+++ b/docs/spec/prediction.parallelogram.decoder.md
@@ -46,6 +46,7 @@ bool ComputeParallelogramPrediction(data_entry_id, ci, in_data,
 void MeshPredictionSchemeParallelogramDecoder_ComputeOriginalValues(num_values) {
   signed_values = seq_int_att_dec_symbols_to_signed_ints[curr_att_dec][curr_att];
   num_components = GetNumComponents();
+  pred_vals.assign(num_components, 0);
   out_values = signed_values;
   PredictionSchemeWrapDecodingTransform_ComputeOriginalValue(pred_vals,
       &signed_values[0], &out_values[0]);

--- a/docs/spec/prediction.texcoords.decoder.md
+++ b/docs/spec/prediction.texcoords.decoder.md
@@ -71,31 +71,31 @@ void MeshPredictionSchemeTexCoordsPortablePredictor_ComputePredictedValue(
     GetPositionForEntryId(data_id, &tip_pos);
     GetPositionForEntryId(next_data_id, &next_pos);
     GetPositionForEntryId(prev_data_id, &prev_pos);
-    SubtractInt64Vectors(prev_pos, next_pos, &pn);
+    SubtractVectors(prev_pos, next_pos, &pn);
     Dot(pn, pn, &pn_norm2_squared);
 
     if (pn_norm2_squared != 0) {
-      SubtractInt64Vectors(tip_pos, next_pos, &cn);
+      SubtractVectors(tip_pos, next_pos, &cn);
       Dot(cn, pn, &cn_dot_pn);
-      SubtractInt64Vectors(p_uv, n_uv, &pn_uv);
+      SubtractVectors(p_uv, n_uv, &pn_uv);
       MultiplyScalar(pn_uv, cn_dot_pn, &vec_mult_1);
       MultiplyScalar(n_uv, pn_norm2_squared, &vec_mult_2);
       AddVectors(vec_mult_1, vec_mult_2, &x_uv);
       MultiplyScalar(pn, cn_dot_pn, &vec_mult);
       DivideScalar(vec_mult, pn_norm2_squared, &vec_div);
       AddVectors(next_pos, vec_div, &x_pos);
-      SubtractInt64Vectors(tip_pos, x_pos, &vec_sub);
+      SubtractVectors(tip_pos, x_pos, &vec_sub);
       Dot(vec_sub, vec_sub, &cx_norm2_squared);
 
       temp_vec.push_back(pn_uv[1]);
       temp_vec.push_back(-pn_uv[0]);
       norm_squared = IntSqrt(cx_norm2_squared * pn_norm2_squared);
       MultiplyScalar(temp_vec, norm_squared, &cx_uv);
-      orientation = pred_tex_coords_orientaitons[curr_att_dec][curr_att].pop_back();
+      orientation = pred_tex_coords_orientations[curr_att_dec][curr_att].pop_back();
       if (orientation)
         AddVectors(x_uv, cx_uv, &temp_vec);
       else
-        SubtractInt64Vectors(x_uv, cx_uv, &temp_vec);
+        SubtractVectors(x_uv, cx_uv, &temp_vec);
       DivideScalar(temp_vec, pn_norm2_squared, &predicted_uv);
       predicted_value_[0] = predicted_uv[0];
       predicted_value_[1] = predicted_uv[1];

--- a/docs/spec/rans.decoding.md
+++ b/docs/spec/rans.decoding.md
@@ -24,9 +24,9 @@ void DecodeTaggedSymbols(num_values, num_components, out_values) {
   BuildSymbolTables(num_symbols_, lut_table_, probability_table_);
   size                                                                                varUI64
   encoded_data                                                                        UI8[size]
-  RansInitDecoder(ans_, &encoded_data[0], size, TAGGED_RANS_BASE);
+  RansInitDecoder(ans_decoder_, &encoded_data[0], size, TAGGED_RANS_BASE);
   for (i = 0; i < num_values; i += num_components) {
-    RansRead(ans_, TAGGED_RANS_BASE, TAGGED_RANS_PRECISION,
+    RansRead(ans_decoder_, TAGGED_RANS_BASE, TAGGED_RANS_PRECISION,
              lut_table_, probability_table_, &size);
     for (j = 0; j < num_components; ++j) {
       val                                                                             f[size]
@@ -55,9 +55,9 @@ void DecodeRawSymbols(num_values, out_values) {
   BuildSymbolTables(num_symbols_, lut_table_, probability_table_);
   size                                                                                varUI64
   buffer                                                                              UI8[size]
-  RansInitDecoder(ans_, &buffer[0], size, l_rans_base);
+  RansInitDecoder(ans_decoder_, &buffer[0], size, l_rans_base);
   for (i = 0; i < num_values; ++i) {
-    RansRead(ans_, l_rans_base, rans_precision,
+    RansRead(ans_decoder_, l_rans_base, rans_precision,
               lut_table_, probability_table_, &val);
     out_values.push_back(val);
   }

--- a/docs/spec/variable.descriptions.md
+++ b/docs/spec/variable.descriptions.md
@@ -230,7 +230,7 @@
 * seq_int_att_dec_compressed
 * pred_cons_multi_is_cease_edge
   * Array for multi parallelogram prediction signifying if the edge is the last edge
-* pred_tex_coords_orientaitons
+* pred_tex_coords_orientations
   * Array signifying orientation for the texture coordinate prediction
 * pred_trasnform_wrap_min
   * Array of minimum clamp values used by the wrap transform
@@ -277,6 +277,8 @@
   * Current rans zero probability
 * prediction_rans_data_size
   * Current size of rans encoded data
+* prediction_rans_data_buffer
+  * Ans encoded prediction data for an attribute
 * tex_coords_num_orientations
   * Current number of orientations for encoded Texture data
 * traversal_stacks_


### PR DESCRIPTION
- Initialized last_vert_added
- Normalized usage of ans_decoder_
- Removed parsing of num_new_vertices
- Removed num_corners
- Added prediction_rans_data_buffer
- Fixed spelling of orientations
- Replaced SubtractInt64Vectors with SubtractVectors
- Initialized pred_vals
- Changed point_to_corner_map from array to counter
- Addresses comments in KhronosGroup/glTF#1114