### PR TITLE
Do not assign std::streampos to std::streamoff

### DIFF
--- a/src/draco/io/obj_decoder.cc
+++ b/src/draco/io/obj_decoder.cc
@@ -54,9 +54,9 @@ Status ObjDecoder::DecodeFromFile(const std::string &file_name,
   if (!file)
     return Status(Status::IO_ERROR);
   // Read the whole file into a buffer.
-  auto file_size = file.tellg();
+  auto pos0 = file.tellg();
   file.seekg(0, std::ios::end);
-  file_size = file.tellg() - file_size;
+  auto file_size = file.tellg() - pos0;
   if (file_size == 0)
     return Status(Status::IO_ERROR);
   file.seekg(0, std::ios::beg);

--- a/src/draco/io/ply_decoder.cc
+++ b/src/draco/io/ply_decoder.cc
@@ -34,9 +34,9 @@ bool PlyDecoder::DecodeFromFile(const std::string &file_name,
   if (!file)
     return false;
   // Read the whole file into a buffer.
-  auto file_size = file.tellg();
+  auto pos0 = file.tellg();
   file.seekg(0, std::ios::end);
-  file_size = file.tellg() - file_size;
+  auto file_size = file.tellg() - pos0;
   if (file_size == 0)
     return false;
   file.seekg(0, std::ios::beg);


### PR DESCRIPTION
This PR fixes compilation error with VS2015:

1>C:\draco\io\ply_decoder.cc(40): error C2666: 'std::fpos<_Mbstatet>::operator ==': 3 overloads have similar conversions
1>         C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\iosfwd(105): note: could be 'bool std::fpos<_Mbstatet>::operator ==(std::streamoff) const'
1>         C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\iosfwd(100): note: or       'bool std::fpos<_Mbstatet>::operator ==(const std::fpos<_Mbstatet> &) const'
