### PR TITLE
Enable static msvc runtime builds if MSVC_RUNTIME=static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,12 +168,15 @@ else ()
     endif ()
   endif ()
 
-  if (ENABLE_TESTS)
-    if (MSVC)
-      # Default runtime selected by cmake collides with Googletest settings,
-      # just force all Draco builds to be static (instead of dll/msvcrt).
-      include("${draco_root}/cmake/msvc_runtime.cmake")
+  if (MSVC)
+    # Default runtime selected by cmake collides with Googletest settings,
+    # just force all Draco builds to be static (instead of dll/msvcrt).
+    if (NOT DEFINED MSVC_RUNTIME AND NOT ENABLE_TESTS)
+       set(MSVC_RUNTIME "dll")
     endif ()
+    include("${draco_root}/cmake/msvc_runtime.cmake")
+  endif ()
+  if (ENABLE_TESTS)
     # Googletest defaults.
     set(GTEST_SOURCE_DIR
         "${draco_root}/../googletest" CACHE STRING


### PR DESCRIPTION
Currently draco is always build with MTd (multrithreaded dll runtime) on Visual Studio, which makes it difficult to use it in projects that require MT runtime. This change enables runtime override when running cmake with an extra param: `-DMSVC_RUNTIME=static`