### PR TITLE
Fix BUILD_SHARED_LIBS=ON GCC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,6 +737,9 @@ if (EMSCRIPTEN)
 else ()
   # Standard Draco libs, encoder and decoder.
   # Object collections that mirror the Draco directory structure.
+  if (BUILD_SHARED_LIBS)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  endif()
   add_library(draco_attributes OBJECT ${draco_attributes_sources})
   add_library(draco_compression_attributes_dec OBJECT
               ${draco_compression_attributes_dec_sources})


### PR DESCRIPTION
I needed the following changes to successfully build with -DBUILD_SHARED_LIBS=ON
Otherwise got the position independent code error.
`relocation R_X86_64_32 against .rodata.str1.1 can not be used when making a shared object; recompile with -fPIC`
There's several ways to do the same so this is just a suggestion. 