### PR TITLE
Require Android NDK path in environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,11 +321,8 @@ It's sometimes useful to build Draco command line tools and run them directly on
 Android devices via adb.
 
 ~~~~~ bash
-# all targets require CMAKE_ANDROID_NDK. It can be set in the environment or
-# within CMake. For example, this would set it in your environment.
+# All targets require CMAKE_ANDROID_NDK. It must be set in the environment.
 $ export CMAKE_ANDROID_NDK=path/to/ndk
-# To set it within CMake, add -DCMAKE_ANDROID_NDK=path/to/ndk to your CMake
-# command.
 
 # arm
 $ cmake path/to/draco -DCMAKE_TOOLCHAIN_FILE=path/to/draco/cmake/toolchains/armv7-android-ndk-libcpp.cmake

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -51,21 +51,19 @@ function (set_compiler_launcher launcher_flag launcher_name)
   endif ()
 endfunction ()
 
-# Terminates CMake execution when $var_name is unset in CMake and environment,
-# and then calls set_variable_if_unset() to ensure variable is set for caller.
+# Terminates CMake execution when $var_name is unset in the environment. Sets
+# CMake variable to the value of the environment variable when the variable is
+# present in the environment.
 macro(require_variable var_name)
-  if ((NOT DEFINED ${var_name}) AND ("$ENV{${var_name}}" STREQUAL ""))
-    message(FATAL_ERROR "${var_name} must be set in cmake or environment.")
+  if ("$ENV{${var_name}}" STREQUAL "")
+    message(FATAL_ERROR "${var_name} must be set in environment.")
   endif ()
   set_variable_if_unset(${var_name} "")
 endmacro ()
 
-# Sets $var_name to $default_value if not already set in CMake or the
-# environment.
+# Sets $var_name to $default_value if not already set in the environment.
 macro (set_variable_if_unset var_name default_value)
-  if (DEFINED ${var_name})
-    return ()
-  elseif (NOT "$ENV{${var_name}}" STREQUAL "")
+  if (NOT "$ENV{${var_name}}" STREQUAL "")
     set(${var_name} $ENV{${var_name}})
   else ()
     set(${var_name} ${default_value})


### PR DESCRIPTION
Updates require_var() and set_variable_if_unset() to use the
environment values for named variables.

CMake processes toolchain files multiple times, and on some
processing runs cache variables are not available. Environment
variables are always available.