### PR TITLE
retain alpha vertex colour attribute when decompressing unity mesh

### DIFF
--- a/src/draco/unity/draco_unity_plugin.cc
+++ b/src/draco/unity/draco_unity_plugin.cc
@@ -113,12 +113,12 @@ int DecodeMeshForUnity(char *data, unsigned int length,
   const auto color_att =
       in_mesh->GetNamedAttribute(draco::GeometryAttribute::COLOR);
   if (color_att != nullptr) {
-    unity_mesh->color = new float[in_mesh->num_points() * 3];
+    unity_mesh->color = new float[in_mesh->num_points() * 4];
     unity_mesh->has_color = true;
     for (draco::PointIndex i(0); i < in_mesh->num_points(); ++i) {
       const draco::AttributeValueIndex val_index = color_att->mapped_index(i);
-      if (!color_att->ConvertValue<float, 3>(
-              val_index, unity_mesh->color + i.value() * 3)) {
+      if (!color_att->ConvertValue<float, 4>(
+              val_index, unity_mesh->color + i.value() * 4)) {
         ReleaseUnityMesh(&unity_mesh);
         return -8;
       }

--- a/unity/DracoMeshLoader.cs
+++ b/unity/DracoMeshLoader.cs
@@ -243,9 +243,9 @@ public unsafe class DracoMeshLoader
 		byte* normaladdr = (byte*)tmpMesh->normal;
 		byte* coloraddr = (byte*)tmpMesh->color;
 		byte* uvaddr = (byte*)tmpMesh->texcoord;
-		for (int i = 0; i < tmpMesh->numVertices; ++i) {
+		for (int i = 0; i < tmpMesh->numVertices; ++i)
+		{
 			int numValuePerVertex = 3;
-
 			for (int j = 0; j < numValuePerVertex; ++j)
 			{
 				int byteStridePerVertex = byteStridePerValue * numValuePerVertex;
@@ -256,12 +256,17 @@ public unsafe class DracoMeshLoader
 				{
 					newNormals[i][j] = *((float*)(normaladdr + OffSet));
 				}
-				if (tmpMesh->hasColor)
-				{
-					newColors[i][j] = *((float*)(coloraddr + OffSet));
-				}
 			}
 
+			if (tmpMesh->hasColor)
+			{
+				numValuePerVertex = 4;
+				for (int j = 0; j < numValuePerVertex; ++j)
+				{
+					int byteStridePerVertex = byteStridePerValue * numValuePerVertex;
+					newColors[i][j] = *((float*)(coloraddr + (i * byteStridePerVertex + byteStridePerValue * j)));
+				}
+			}
 
 			if (tmpMesh->hasTexcoord)
 			{


### PR DESCRIPTION
The alpha colour for vertex colours wasn't getting decompressed. This seems to be working, but I haven't run any automated tests or done extensive testing for this.