### PR TITLE
Add a flag for cmake to generate IE11 compatible JS decoder modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,9 @@ set(draco_maya_plug_sources
 if (EMSCRIPTEN)
   # Draco js decoder.
   require_compiler_flag("-s ALLOW_MEMORY_GROWTH=1" YES)
+  if (IE_COMPATIBLE)
+    require_compiler_flag("-s LEGACY_VM_SUPPORT=1" YES)
+  endif ()
   require_compiler_flag("-Wno-almost-asm" YES)
   require_compiler_flag("--memory-init-file 0" YES)
   require_compiler_flag("-fno-omit-frame-pointer" YES)
@@ -625,7 +628,11 @@ if (EMSCRIPTEN)
 
   if (CMAKE_BUILD_TYPE STREQUAL "")
     # Force -O3 when no build type is specified.
-    add_compiler_flag_if_supported("-O3")
+    if (IE_COMPATIBLE)
+      add_compiler_flag_if_supported("-g")
+    else ()
+      add_compiler_flag_if_supported("-O3")
+    endif ()
   endif ()
 
   set(draco_js_dec_idl

--- a/Makefile.decoder.emcc
+++ b/Makefile.decoder.emcc
@@ -59,7 +59,11 @@ ALL_C_OPTS := -std=c++11
 #ALL_C_OPTS += -s USE_SDL=0 -s USE_SDL_IMAGE=0 -s USE_SDL_TTF=0
 
 # Options for speed.
-ALL_C_OPTS += -O3
+ifeq ($(IE_COMPATIBLE), true)
+    ALL_C_OPTS += -g
+else 
+    ALL_C_OPTS += -O3
+endif
 ALL_C_OPTS += -s NO_FILESYSTEM=1 -s ELIMINATE_DUPLICATE_FUNCTIONS=1
 ALL_C_OPTS += -s EXPORTED_RUNTIME_METHODS=[]
 ALL_C_OPTS += -s PRECISE_F32=1
@@ -77,6 +81,11 @@ endif
 # will hurt performance.
 ALL_C_OPTS += -s ALLOW_MEMORY_GROWTH=1
 #ALL_C_OPTS += -s TOTAL_MEMORY=67108864
+
+# Allow legacy vm support for IE11
+ifeq ($(IE_COMPATIBLE), true)
+    ALL_C_OPTS += -s LEGACY_VM_SUPPORT=1
+endif
 
 # Export the main module as "DracoDecoderModule".
 ALL_C_OPTS += -s MODULARIZE=1 -s EXPORT_NAME="'DracoDecoderModule'"

--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ $ cmake path/to/draco -DCMAKE_TOOLCHAIN_FILE=/path/to/Emscripten.cmake
 $ make
 ~~~~~
 
+To build a decoder module that is compatible with IE11 (at the cost of a slightly larger resulting module), set the `IE_COMPATIBLE` variable to `true` when generating the cmake file.
+
+~~~~~ bash
+$ cmake path/to/draco -DCMAKE_TOOLCHAIN_FILE=/path/to/Emscripten.cmake -DIE_COMPATIBLE=true
+~~~~~
+
 WebAssembly Decoder
 -------------------
 


### PR DESCRIPTION
The current JavaScript decoder module fails when run in IE11. 

This allows an `IE_COMPATIBLE` variable to be set when generating the cmake files in order to build a module that works in IE11 by providing polyfills, at a small hit to module size (1MB), with the solution proposed in https://github.com/kripken/emscripten/issues/6204