### PR TITLE
fixed iteration over original attribute

### DIFF
--- a/src/draco/compression/attributes/sequential_integer_attribute_encoder.cc
+++ b/src/draco/compression/attributes/sequential_integer_attribute_encoder.cc
@@ -80,7 +80,7 @@ bool SequentialIntegerAttributeEncoder::TransformAttributeToPortableFormat(
     }
     // Go over all points of the original attribute and update the mapping in
     // the portable attribute.
-    for (PointIndex i(0); i < encoder()->point_cloud()->num_points(); ++i) {
+    for (PointIndex i(0); i < orig_att->size(); ++i) {
       portable_att->SetPointMapEntry(
           i, value_to_value_map[orig_att->mapped_index(i)]);
     }


### PR DESCRIPTION
Before this change the iteration over all points could cause crashes in scenarios where the size of the attributes differ from the amount of points in the pointcloud.