### PR TITLE
fixed size of vector in transformation to portable format

### DIFF
--- a/src/draco/compression/attributes/sequential_integer_attribute_encoder.cc
+++ b/src/draco/compression/attributes/sequential_integer_attribute_encoder.cc
@@ -73,7 +73,7 @@ bool SequentialIntegerAttributeEncoder::TransformAttributeToPortableFormat(
     const PointAttribute *const orig_att = attribute();
     PointAttribute *const portable_att = portable_attribute();
     IndexTypeVector<AttributeValueIndex, AttributeValueIndex>
-        value_to_value_map(orig_att->size());
+        value_to_value_map(encoder()->point_cloud()->num_points());
     for (int i = 0; i < point_ids.size(); ++i) {
       value_to_value_map[orig_att->mapped_index(point_ids[i])] =
           AttributeValueIndex(i);


### PR DESCRIPTION
In some cases with attribute sizes that differ from the amount of points the loop in the end of TransformAttributeToPortableFormat could cause crashes because it accesses non allocated elements of the vector.
This changes the vector size so this does not happen anymore.