### PR TITLE
Added suggestion on error message for .obj

### DIFF
--- a/src/draco/io/obj_decoder.cc
+++ b/src/draco/io/obj_decoder.cc
@@ -430,7 +430,7 @@ bool ObjDecoder::ParseFace(Status *status) {
       }
     }
     if (num_indices < 3 || num_indices > 4) {
-      *status = Status(Status::ERROR, "Invalid number of indices on a face");
+      *status = Status(Status::ERROR, "Invalid number of indices on a face. Maybe try to triangulate faces?");
       return false;
     }
     // Either one or two new triangles.


### PR DESCRIPTION
Obj can create a single face with a lot vertices (e.g. in Maya export). obj_decoder.cc support only 4 vertices per face. if a face got more than 4 vertices, a message "Invalid number of indices on a face" is displayed in console.

I added a suggestion to let the user know how to fix it.

Related to #458 

PS: great work on draco, the output size is impressive, thanks for doing the hard work and making it opensource