### PR TITLE
animation/keyframe_animation: Use unsigned values instead for variables that store quantities

### DIFF
--- a/src/draco/animation/keyframe_animation.cc
+++ b/src/draco/animation/keyframe_animation.cc
@@ -21,7 +21,7 @@ KeyframeAnimation::KeyframeAnimation() {}
 bool KeyframeAnimation::SetTimestamps(
     const std::vector<TimestampType> &timestamp) {
   // Already added attributes.
-  const int32_t num_frames = timestamp.size();
+  const uint32_t num_frames = static_cast<uint32_t>(timestamp.size());
   if (num_attributes() > 0) {
     // Timestamp attribute could be added only once.
     if (timestamps()->size()) {

--- a/src/draco/animation/keyframe_animation.h
+++ b/src/draco/animation/keyframe_animation.h
@@ -56,10 +56,10 @@ class KeyframeAnimation : public PointCloud {
   }
 
   // Number of frames should be equal to number points in the point cloud.
-  void set_num_frames(int32_t num_frames) { set_num_points(num_frames); }
-  int32_t num_frames() const { return static_cast<int32_t>(num_points()); }
+  void set_num_frames(uint32_t num_frames) { set_num_points(num_frames); }
+  uint32_t num_frames() const { return static_cast<int32_t>(num_points()); }
 
-  int32_t num_animations() const { return num_attributes() - 1; }
+  uint32_t num_animations() const { return num_attributes() - 1; }
 
  private:
   // Attribute id of timestamp is fixed to 0.

--- a/src/draco/point_cloud/point_cloud.h
+++ b/src/draco/point_cloud/point_cloud.h
@@ -58,8 +58,8 @@ class PointCloud {
   const PointAttribute *GetAttributeByUniqueId(uint32_t id) const;
   int32_t GetAttributeIdByUniqueId(uint32_t unique_id) const;
 
-  int32_t num_attributes() const {
-    return static_cast<int32_t>(attributes_.size());
+  uint32_t num_attributes() const {
+    return static_cast<uint32_t>(attributes_.size());
   }
   const PointAttribute *attribute(int32_t att_id) const {
     DRACO_DCHECK_LE(0, att_id);


### PR DESCRIPTION
Quantities should never be negative. Therefore we should use unsigned values instead of signed values to store them.