### PR TITLE
attributes/point_d_vector: Prevent a singend/unsigned mismatch

### DIFF
--- a/src/draco/compression/attributes/point_d_vector.h
+++ b/src/draco/compression/attributes/point_d_vector.h
@@ -42,7 +42,7 @@ class PseudoPointD {
 
   // Specifically copies referenced memory
   void swap(PseudoPointD &other) noexcept {
-    for (auto dim = 0; dim < dimension_; dim += 1)
+    for (internal_t dim = 0; dim < dimension_; dim += 1)
       std::swap(mem_[dim], other.mem_[dim]);
   }
 


### PR DESCRIPTION
This PR fixes a MSCV compiler warning.