### PR TITLE
Add MetadataQuerier.GetIntEntryArray to JavaScript bindings

### DIFF
--- a/src/draco/javascript/emscripten/decoder_webidl_wrapper.cc
+++ b/src/draco/javascript/emscripten/decoder_webidl_wrapper.cc
@@ -40,6 +40,15 @@ long MetadataQuerier::GetIntEntry(const Metadata &metadata,
   return value;
 }
 
+void MetadataQuerier::GetIntEntryArray(const draco::Metadata &metadata,
+                                       const char *entry_name,
+                                       DracoInt32Array *out_values) const {
+  const std::string name(entry_name);
+  std::vector<int32_t> values;
+  metadata.GetEntryIntArray(name, &values);
+  out_values->SetValues(values.data(), values.size());
+}
+
 double MetadataQuerier::GetDoubleEntry(const Metadata &metadata,
                                        const char *entry_name) const {
   double value = 0;
@@ -298,9 +307,6 @@ void Decoder::SkipAttributeTransform(draco_GeometryAttribute_Type att_type) {
 }
 
 const Metadata *Decoder::GetMetadata(const PointCloud &pc) const {
-  if (!pc.GetMetadata()) {
-    return nullptr;
-  }
   return pc.GetMetadata();
 }
 

--- a/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
+++ b/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
@@ -31,38 +31,8 @@ typedef draco::EncodedGeometryType draco_EncodedGeometryType;
 typedef draco::Status draco_Status;
 typedef draco::Status::Code draco_StatusCode;
 
-// To generate Draco JabvaScript bindings you must have emscripten installed.
+// To generate Draco JavaScript bindings you must have emscripten installed.
 // Then run make -f Makefile.emcc jslib.
-
-class MetadataQuerier {
- public:
-  MetadataQuerier();
-
-  bool HasEntry(const draco::Metadata &metadata, const char *entry_name) const;
-
-  // This function does not guarantee that entry's type is long.
-  long GetIntEntry(const draco::Metadata &metadata,
-                   const char *entry_name) const;
-
-  // This function does not guarantee that entry's type is double.
-  double GetDoubleEntry(const draco::Metadata &metadata,
-                        const char *entry_name) const;
-
-  // This function does not guarantee that entry's type is char*.
-  const char *GetStringEntry(const draco::Metadata &metadata,
-                             const char *entry_name);
-
-  long NumEntries(const draco::Metadata &metadata) const;
-  const char *GetEntryName(const draco::Metadata &metadata, int entry_id);
-
- private:
-  // Cached values for metadata entries.
-  std::vector<std::string> entry_names_;
-  const draco::Metadata *entry_names_metadata_;
-
-  // Cached value for GetStringEntry() to avoid scoping issues.
-  std::string last_string_returned_;
-};
 
 class DracoFloat32Array {
  public:
@@ -164,6 +134,40 @@ class DracoUInt32Array {
 
  private:
   std::vector<uint32_t> values_;
+};
+
+class MetadataQuerier {
+ public:
+  MetadataQuerier();
+
+  bool HasEntry(const draco::Metadata &metadata, const char *entry_name) const;
+
+  // This function does not guarantee that entry's type is long.
+  long GetIntEntry(const draco::Metadata &metadata,
+                   const char *entry_name) const;
+
+  // This function does not guarantee that entry types are long.
+  void GetIntEntryArray(const draco::Metadata &metadata, const char *entry_name,
+                        DracoInt32Array *out_values) const;
+
+  // This function does not guarantee that entry's type is double.
+  double GetDoubleEntry(const draco::Metadata &metadata,
+                        const char *entry_name) const;
+
+  // This function does not guarantee that entry's type is char*.
+  const char *GetStringEntry(const draco::Metadata &metadata,
+                             const char *entry_name);
+
+  long NumEntries(const draco::Metadata &metadata) const;
+  const char *GetEntryName(const draco::Metadata &metadata, int entry_id);
+
+ private:
+  // Cached values for metadata entries.
+  std::vector<std::string> entry_names_;
+  const draco::Metadata *entry_names_metadata_;
+
+  // Cached value for GetStringEntry() to avoid scoping issues.
+  std::string last_string_returned_;
 };
 
 // Class used by emscripten WebIDL Binder [1] to wrap calls to decode Draco

--- a/src/draco/javascript/emscripten/draco_web_decoder.idl
+++ b/src/draco/javascript/emscripten/draco_web_decoder.idl
@@ -111,22 +111,6 @@ interface Status {
   [Const] DOMString error_msg();
 };
 
-interface MetadataQuerier {
-  void MetadataQuerier();
-
-  boolean HasEntry([Ref, Const] Metadata metadata,
-                   [Const] DOMString entry_name);
-  long GetIntEntry([Ref, Const] Metadata metadata,
-                   [Const] DOMString entry_name);
-  double GetDoubleEntry([Ref, Const] Metadata metadata,
-                        [Const] DOMString entry_name);
-  [Const] DOMString GetStringEntry([Ref, Const] Metadata metadata,
-                                   [Const] DOMString entry_name);
-
-  long NumEntries([Ref, Const] Metadata metadata);
-  [Const] DOMString GetEntryName([Ref, Const] Metadata metadata, long entry_id);
-};
-
 // Draco version of typed arrays. The memory of these arrays is allocated on the
 // emscripten heap.
 interface DracoFloat32Array {
@@ -169,6 +153,25 @@ interface DracoUInt32Array {
   void DracoUInt32Array();
   unsigned long GetValue(long index);
   long size();
+};
+
+interface MetadataQuerier {
+  void MetadataQuerier();
+
+  boolean HasEntry([Ref, Const] Metadata metadata,
+                   [Const] DOMString entry_name);
+  long GetIntEntry([Ref, Const] Metadata metadata,
+                   [Const] DOMString entry_name);
+  void GetIntEntryArray([Ref, Const] Metadata metadata,
+                        [Const] DOMString entry_name,
+                        DracoInt32Array out_values);
+  double GetDoubleEntry([Ref, Const] Metadata metadata,
+                        [Const] DOMString entry_name);
+  [Const] DOMString GetStringEntry([Ref, Const] Metadata metadata,
+                                   [Const] DOMString entry_name);
+
+  long NumEntries([Ref, Const] Metadata metadata);
+  [Const] DOMString GetEntryName([Ref, Const] Metadata metadata, long entry_id);
 };
 
 interface Decoder {


### PR DESCRIPTION
We need this to read some internal metadata on our geometries. If possible, we would like to get this deployed through an official release soonish. 