### PR TITLE
TravisCI: Use newer linux images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,17 @@ language: cpp
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: clang
     - os: linux
-      dist: trusty
+      dist: xenial
       compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-        env:
-          - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
     - os: osx
       osx_image: xcode8.3
       compiler: clang
 
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
     - ccache
     - cmake
@@ -31,9 +21,6 @@ addons:
 before_install:
   - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew update; fi
   - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew install ccache; fi
-  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]] && [[ "${CXX}" = "g++" ]]; then
-      export CXX="g++-4.9" CC="gcc-4.9";
-    fi
 
 script:
   # Output version info for compilers, cmake, and make


### PR DESCRIPTION
Update the linux jobs to use Xenial. This simplifies our setup: We no longer need to check for the presence of packages other than ccache and cmake.