### PR TITLE
Fix: Unity requires static libs for iOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1010,7 +1010,11 @@ else()
               $<TARGET_OBJECTS:draco_points_dec>
               $<TARGET_OBJECTS:draco_points_enc>)
   if(BUILD_UNITY_PLUGIN)
-    add_library(dracodec_unity MODULE
+    set(UNITY_TYPE MODULE)
+    if(IOS)
+      set(UNITY_TYPE STATIC)
+    endif()
+    add_library(dracodec_unity ${UNITY_TYPE}
                 ${draco_version_sources}
                 $<TARGET_OBJECTS:draco_attributes>
                 $<TARGET_OBJECTS:draco_compression_attributes_dec>


### PR DESCRIPTION
Changed the library type from MODULE to STATIC for dracodec_unity IOS only. For other platforms it stays MODULE.

Tested with CMake 3.14.5 (has built-in iOS toolchain)

```bash
cmake .. -G Xcode -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=armv7\;armv7s\;arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.0 -DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO -DBUILD_UNITY_PLUGIN=ON
```