### PR TITLE
draco cmake: Defer windows shared lib check until after plugin checks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,6 @@ option(BUILD_FOR_GLTF "" OFF)
 option(BUILD_MAYA_PLUGIN "Build plugin library for Maya." OFF)
 option(BUILD_USD_PLUGIN "Build plugin library for USD." OFF)
 
-if(WIN32 AND BUILD_SHARED_LIBS)
-  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-  include(GenerateExportHeader)
-endif()
-
 if(BUILD_FOR_GLTF)
   # Override settings when building for GLTF.
   draco_enable_feature(FEATURE "DRACO_MESH_COMPRESSION_SUPPORTED")
@@ -135,6 +130,10 @@ endif()
 if(BUILD_USD_PLUGIN)
   set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared library for USD plugin.")
   draco_enable_feature(FEATURE "BUILD_USD_PLUGIN")
+endif()
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 endif()
 
 if(ENABLE_EXTRA_SPEED)


### PR DESCRIPTION
We rely upon CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS for windows DLL
support, but we must defer the BUILD_SHARED_LIBS check until after the
plugin args are checked since the plugin checks can enable BUILD_SHARED_LIBS.

Without this change Visual Studio will not create import libs for the draco DLLs,
and that breaks the build.