### PR TITLE
Fix unit test golden file reading (#471)

### DIFF
--- a/src/draco/core/draco_test_utils.cc
+++ b/src/draco/core/draco_test_utils.cc
@@ -48,7 +48,7 @@ bool GenerateGoldenFile(const std::string &golden_file_name, const void *data,
 bool CompareGoldenFile(const std::string &golden_file_name, const void *data,
                        int data_size) {
   const std::string golden_path = GetTestFileFullPath(golden_file_name);
-  std::ifstream in_file(golden_path);
+  std::ifstream in_file(golden_path, std::ios::binary);
   if (!in_file || data_size < 0)
     return false;
   const char *const data_c8 = static_cast<const char *>(data);


### PR DESCRIPTION
Apparently MSVC runtime in text mode interprets 0x1a as end of file. So binary mode is necessary for reading file.