### PR TITLE
draco: Add dummy sources to draco, dracodec, and dracoenc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1003,7 +1003,7 @@ else()
   endif()
 
   list(APPEND draco_header_only_targets
-       draco_compression_attributes_pred_schemes_dec
+       draco dracodec dracoenc draco_compression_attributes_pred_schemes_dec
        draco_compression_mesh_traverser draco_dec_config draco_enc_config)
 
   # For now, enable deduplication for both encoder and decoder.


### PR DESCRIPTION
This is a workaround for two issues with CMake's Xcode generator:
- Setting the LINK_LANGUAGE property does not work.
- Library targets that only combine other object files do not build in
  Xcode because of some other issue in the generator. They don't fail
  at build time: Xcode just does not build them.

The combined behavior of the two issues forces addition of dummy source
files to the listed targets.

Fixes issue https://github.com/google/draco/issues/593