### PR TITLE
Additions to JS decoder API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/_site
+build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 docs/_site
-build

--- a/src/draco/javascript/emscripten/decoder_webidl_wrapper.cc
+++ b/src/draco/javascript/emscripten/decoder_webidl_wrapper.cc
@@ -49,6 +49,16 @@ void MetadataQuerier::GetIntEntryArray(const draco::Metadata &metadata,
   out_values->MoveData(std::move(values));
 }
 
+void MetadataQuerier::GetDoubleEntryArray(const draco::Metadata &metadata,
+                                       const char *entry_name,
+                                       DracoFloat32Array *out_values) const {
+  const std::string name(entry_name);
+  std::vector<double> values;
+  metadata.GetEntryDoubleArray(name, &values);
+  std::vector<float> floats(values.begin(), values.end());
+  out_values->MoveData(std::move(floats));
+}
+
 double MetadataQuerier::GetDoubleEntry(const Metadata &metadata,
                                        const char *entry_name) const {
   double value = 0;

--- a/src/draco/javascript/emscripten/decoder_webidl_wrapper.cc
+++ b/src/draco/javascript/emscripten/decoder_webidl_wrapper.cc
@@ -78,6 +78,15 @@ const char *MetadataQuerier::GetStringEntry(const Metadata &metadata,
   return value;
 }
 
+void MetadataQuerier::GetBinaryEntry(const Metadata &metadata,
+                                            const char *entry_name,
+                                            DracoUInt8Array *out_values) const {
+  const std::string name(entry_name);
+  std::vector<uint8_t> values;
+  metadata.GetEntryBinary(name, &values);
+  out_values->MoveData(std::move(values));
+}
+
 long MetadataQuerier::NumEntries(const Metadata &metadata) const {
   return metadata.num_entries();
 }

--- a/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
+++ b/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
@@ -54,7 +54,6 @@ class DracoArray {
   std::vector<T> values_;
 };
 
-using DracoDoubleArray = DracoArray<double>;
 using DracoFloat32Array = DracoArray<float>;
 using DracoInt8Array = DracoArray<int8_t>;
 using DracoUInt8Array = DracoArray<uint8_t>;

--- a/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
+++ b/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
@@ -48,6 +48,8 @@ class DracoArray {
 
   int size() const { return values_.size(); }
 
+  T* data() { return values_.data(); }
+
  private:
   std::vector<T> values_;
 };

--- a/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
+++ b/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
@@ -52,6 +52,7 @@ class DracoArray {
   std::vector<T> values_;
 };
 
+using DracoDoubleArray = DracoArray<double>;
 using DracoFloat32Array = DracoArray<float>;
 using DracoInt8Array = DracoArray<int8_t>;
 using DracoUInt8Array = DracoArray<uint8_t>;
@@ -73,6 +74,9 @@ class MetadataQuerier {
   // This function does not guarantee that entry types are long.
   void GetIntEntryArray(const draco::Metadata &metadata, const char *entry_name,
                         DracoInt32Array *out_values) const;
+
+  void GetDoubleEntryArray(const draco::Metadata &metadata, const char *entry_name,
+                        DracoFloat32Array *out_values) const;
 
   // This function does not guarantee that entry's type is double.
   double GetDoubleEntry(const draco::Metadata &metadata,

--- a/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
+++ b/src/draco/javascript/emscripten/decoder_webidl_wrapper.h
@@ -87,6 +87,10 @@ class MetadataQuerier {
   const char *GetStringEntry(const draco::Metadata &metadata,
                              const char *entry_name);
 
+  void GetBinaryEntry(const draco::Metadata &metadata,
+                             const char *entry_name,
+                             DracoUInt8Array *out_values) const;
+
   long NumEntries(const draco::Metadata &metadata) const;
   const char *GetEntryName(const draco::Metadata &metadata, int entry_id);
 

--- a/src/draco/javascript/emscripten/draco_web_decoder.idl
+++ b/src/draco/javascript/emscripten/draco_web_decoder.idl
@@ -194,6 +194,9 @@ interface MetadataQuerier {
                         DracoFloat32Array out_values);
   double GetDoubleEntry([Ref, Const] Metadata metadata,
                         [Const] DOMString entry_name);
+  void GetBinaryEntry([Ref, Const] Metadata metadata,
+                        [Const] DOMString entry_name,
+                        DracoUInt8Array out_values);
   [Const] DOMString GetStringEntry([Ref, Const] Metadata metadata,
                                    [Const] DOMString entry_name);
 

--- a/src/draco/javascript/emscripten/draco_web_decoder.idl
+++ b/src/draco/javascript/emscripten/draco_web_decoder.idl
@@ -134,42 +134,49 @@ interface DracoFloat32Array {
   void DracoFloat32Array();
   float GetValue(long index);
   long size();
+  VoidPtr data();
 };
 
 interface DracoInt8Array {
   void DracoInt8Array();
   byte GetValue(long index);
   long size();
+  VoidPtr data();
 };
 
 interface DracoUInt8Array {
   void DracoUInt8Array();
   octet GetValue(long index);
   long size();
+  VoidPtr data();
 };
 
 interface DracoInt16Array {
   void DracoInt16Array();
   short GetValue(long index);
   long size();
+  VoidPtr data();
 };
 
 interface DracoUInt16Array {
   void DracoUInt16Array();
   unsigned short GetValue(long index);
   long size();
+  VoidPtr data();
 };
 
 interface DracoInt32Array {
   void DracoInt32Array();
   long GetValue(long index);
   long size();
+  VoidPtr data();
 };
 
 interface DracoUInt32Array {
   void DracoUInt32Array();
   unsigned long GetValue(long index);
   long size();
+  VoidPtr data();
 };
 
 interface MetadataQuerier {

--- a/src/draco/javascript/emscripten/draco_web_decoder.idl
+++ b/src/draco/javascript/emscripten/draco_web_decoder.idl
@@ -182,6 +182,9 @@ interface MetadataQuerier {
   void GetIntEntryArray([Ref, Const] Metadata metadata,
                         [Const] DOMString entry_name,
                         DracoInt32Array out_values);
+  void GetDoubleEntryArray([Ref, Const] Metadata metadata,
+                        [Const] DOMString entry_name,
+                        DracoFloat32Array out_values);
   double GetDoubleEntry([Ref, Const] Metadata metadata,
                         [Const] DOMString entry_name);
   [Const] DOMString GetStringEntry([Ref, Const] Metadata metadata,


### PR DESCRIPTION
I'd like to propose some additions to the JS decoder API (hope I haven't missed something in the API that makes these changes redundant):

* add GetDoubleEntryArray to MetadataQuerier
* add GetBinaryEntryArray to MetadataQuerier
* add data() method to DracoArray

I am storing arrays as metadata and I was looking for an easy way to copy the data over form the emscripten heap rather than iterating:

```
const arr = new draco.DracoFloat32Array();
metaQuerier.GetDoubleEntryArray(metadata, name, arr);
const size = arr.size();
const ptr = arr.data().ptr;
```

Then e.g.
```
entry = new Float32Array(draco.HEAPU8.buffer.slice(ptr, ptr + size * 4));
```

instead of 
```
entry = new Float32Array(size);
for (let idx = 0; idx < size; idx++) {
  entry[idx] = arr.GetValue(idx);
}
```