### PR TITLE
Uses SVG logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <p align="center">
-<img src="docs/DracoLogo.jpeg" />
+<img width="350px" src="docs/artwork/draco3d-vert.svg" />
 </p>
 
 News


### PR DESCRIPTION
Super minor, but I was looking at the repo and noticed the logo was blurry, poked around a bit and found the svg version already in the repo, so why not try and use it for the README?