### PR TITLE
Fix typo in CMake macro draco_add_executable()

### DIFF
--- a/cmake/draco_targets.cmake
+++ b/cmake/draco_targets.cmake
@@ -130,7 +130,7 @@ macro(draco_add_executable)
   endif()
 
   if(BUILD_SHARED_LIBS AND (MSVC OR WIN32))
-    target_compile_definitions(${lib_NAME} PRIVATE "DRACO_BUILDING_DLL=0")
+    target_compile_definitions(${exe_NAME} PRIVATE "DRACO_BUILDING_DLL=0")
   endif()
 
   if(exe_LIB_DEPS)


### PR DESCRIPTION
$lib_NAME -> $exe_NAME.