### PR TITLE
Support building mingw static and dynamic at the same time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,7 +804,7 @@ else()
       draco_points_enc)
 
   # Library targets that consume the object collections.
-  if(MSVC OR WIN32)
+  if(MSVC)
     # In order to produce a DLL and import library the Windows tools require
     # that the exported symbols are part of the DLL target. The unfortunate side
     # effect of this is that a single configuration cannot output both the

--- a/cmake/draco_build_definitions.cmake
+++ b/cmake/draco_build_definitions.cmake
@@ -6,7 +6,7 @@ set(DRACO_CMAKE_DRACO_BUILD_DEFINITIONS_CMAKE_ 1)
 # Utility for controlling the main draco library dependency. This changes in
 # shared builds, and when an optional target requires a shared library build.
 macro(set_draco_target)
-  if(MSVC OR WIN32)
+  if(MSVC)
     set(draco_dependency draco)
     set(draco_plugin_dependency ${draco_dependency})
   else()

--- a/cmake/draco_install.cmake
+++ b/cmake/draco_install.cmake
@@ -55,7 +55,7 @@ macro(draco_setup_install_target)
   install(TARGETS draco_encoder DESTINATION
                   "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}")
 
-  if(WIN32)
+  if(MSVC)
     install(TARGETS draco DESTINATION
                     "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
   else()

--- a/cmake/draco_targets.cmake
+++ b/cmake/draco_targets.cmake
@@ -163,7 +163,7 @@ endmacro()
 # cmake-format: off
 #   - OUTPUT_NAME: Override output file basename. Target basename defaults to
 #     NAME. OUTPUT_NAME is ignored when BUILD_SHARED_LIBS is enabled and CMake
-#     is generating a build for which MSVC or WIN32 are true. This is to avoid
+#     is generating a build for which MSVC are true. This is to avoid
 #     output basename collisions with DLL import libraries.
 #   - TEST: Flag. Presence means treat library as a test.
 #   - DEFINES: List of preprocessor macro definitions.
@@ -259,7 +259,7 @@ macro(draco_add_library)
   endif()
 
   if(lib_OUTPUT_NAME)
-    if(NOT (BUILD_SHARED_LIBS AND (MSVC OR WIN32)))
+    if(NOT (BUILD_SHARED_LIBS AND MSVC))
       set_target_properties(${lib_NAME}
                             PROPERTIES OUTPUT_NAME ${lib_OUTPUT_NAME})
     endif()

--- a/cmake/draco_targets.cmake
+++ b/cmake/draco_targets.cmake
@@ -163,8 +163,8 @@ endmacro()
 # cmake-format: off
 #   - OUTPUT_NAME: Override output file basename. Target basename defaults to
 #     NAME. OUTPUT_NAME is ignored when BUILD_SHARED_LIBS is enabled and CMake
-#     is generating a build for which MSVC are true. This is to avoid
-#     output basename collisions with DLL import libraries.
+#     is generating a build for which MSVC is true. This is to avoid output
+#     basename collisions with DLL import libraries.
 #   - TEST: Flag. Presence means treat library as a test.
 #   - DEFINES: List of preprocessor macro definitions.
 #   - INCLUDES: list of include directories for the target.


### PR DESCRIPTION
Mingw-w64 (and Cygwin) uses the following extension schema for generated libraries:
- Shared library: `.dll`
- Import library:  `.a.dll`
- Static library: `.a`

Notice that there is no basename collision between shared and static libraries, so it is safe to support generating both types at the same time.

The basename collision issue happens only in MSVC (to the best of my knowledge).