### PR TITLE
fix: Linking dracodec_unity macOS bundle works again

### DIFF
--- a/cmake/draco_targets.cmake
+++ b/cmake/draco_targets.cmake
@@ -321,7 +321,7 @@ macro(draco_add_library)
   endif()
 
   # VERSION and SOVERSION as necessary
-  if(NOT lib_TYPE STREQUAL STATIC)
+  if(NOT lib_TYPE STREQUAL STATIC AND NOT lib_TYPE STREQUAL MODULE)
     set_target_properties(${lib_NAME} PROPERTIES VERSION ${DRACO_VERSION})
     if(NOT MSVC)
       set_target_properties(${lib_NAME} PROPERTIES SOVERSION ${DRACO_SOVERSION})


### PR DESCRIPTION
Error must have been introduced with #676

Using the Ninja generator and Apple clang version 12.0.0 (clang-1200.0.32.29)

The error before was:

```
[build] : && /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -g -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk -bundle -Wl,-headerpad_max_install_names -compatibility_version 1.0.0 -current_version 1.4.1 -o dracodec_unity.bundle/Contents/MacOS/dracodec_unity CMakeFiles/draco_unity_plugin.dir/src/draco/unity/draco_unity_plugin.cc.o  libdraco.a && :
[build] clang: error: invalid argument '-compatibility_version 1.0.0' only allowed with '-dynamiclib'
```


