### PR TITLE
Support files larger than 2GB in Win64

### DIFF
--- a/src/draco/io/stdio_file_reader.cc
+++ b/src/draco/io/stdio_file_reader.cc
@@ -87,7 +87,13 @@ size_t StdioFileReader::GetFileSize() {
     return false;
   }
 
+  
+
+  #if defined(_WIN64)
+  const size_t file_size = static_cast<size_t>(_ftelli64(file_));
+  #else
   const size_t file_size = static_cast<size_t>(ftell(file_));
+  #endif
   rewind(file_);
 
   return file_size;


### PR DESCRIPTION
Hi maintainers!

I love this terrific project.

I've built the 1.4.1 version using the latest version of Visual Studio 2019 (MSBUILD 16.9.0) for Win64.

The resulting encoder worked very well for small PLY files.

However, for files larger than 2GB, the encoder failed without error messages.

I've figured out the problem through debugging.

`ftell` was the problem: it failed to locate bytes after 2GBs. So, it cannot return the right file size.

I suggest here using `_ftelli64` explicitly, only for Win64.

Thank you, guys.
