### PR TITLE
draco: Complete the large file support fix in the stdio reader.

### DIFF
--- a/cmake/draco_build_definitions.cmake
+++ b/cmake/draco_build_definitions.cmake
@@ -63,6 +63,11 @@ macro(draco_set_build_definitions)
     if(BUILD_SHARED_LIBS)
       set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
     endif()
+  else()
+    if(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+      # Ensure 64-bit platforms can support large files.
+      list(APPEND draco_defines "_LARGEFILE_SOURCE" "_FILE_OFFSET_BITS=64")
+    endif()
   endif()
 
   if(ANDROID)

--- a/src/draco/io/stdio_file_reader.cc
+++ b/src/draco/io/stdio_file_reader.cc
@@ -87,13 +87,14 @@ size_t StdioFileReader::GetFileSize() {
     return false;
   }
 
-  
-
-  #if defined(_WIN64)
+#if _FILE_OFFSET_BITS == 64
+  const size_t file_size = static_cast<size_t>(ftello(file_));
+#elif defined _WIN64
   const size_t file_size = static_cast<size_t>(_ftelli64(file_));
-  #else
+#else
   const size_t file_size = static_cast<size_t>(ftell(file_));
-  #endif
+#endif
+
   rewind(file_);
 
   return file_size;


### PR DESCRIPTION
Builds on the Windows-only fix added in
https://github.com/google/draco/pull/691