### PR TITLE
Fix fuzzer build script

### DIFF
--- a/src/draco/tools/fuzz/build.sh
+++ b/src/draco/tools/fuzz/build.sh
@@ -19,7 +19,7 @@
 cmake $SRC/draco
 # The draco_decoder and draco_encoder binaries don't build nicely with OSS-Fuzz
 # options, so just build the Draco shared libraries.
-make -j$(nproc) draco
+make -j$(nproc)
 
 # build fuzzers
 for fuzzer in $(find $SRC/draco/src/draco/tools/fuzz -name '*.cc'); do


### PR DESCRIPTION
Draco has been failing on OSS-Fuzz for a while now (last time it built was back in December 2020). This should fix the build so the fuzzers can run again.