### PR TITLE
bugfix: attribute NORMAL decoding error in gcc and clang compiler

### DIFF
--- a/src/draco/compression/attributes/normal_compression_utils.h
+++ b/src/draco/compression/attributes/normal_compression_utils.h
@@ -318,7 +318,7 @@ class OctahedronToolBox {
 
     // Remaining coordinate can be computed by projecting the (y, z) values onto
     // the surface of the octahedron.
-    const float x = 1.f - abs(y) - abs(z);
+    const float x = 1.f - std::abs(y) - std::abs(z);
 
     // |x| is essentially a signed distance from the diagonal edges of the
     // diamond shown on the figure above. It is positive for all points in the


### PR DESCRIPTION
bugfix: Attribute NORMAL decoding error in gcc and clang compiler: std c lib function int abs(int) can implicitly convert `float` to`int` and return an integer, which is not expected as to MSVC compiler.