### PR TITLE
Fixed decoding of large meshes encoded with MESH_SEQUENTIAL_ENCODING

### DIFF
--- a/src/draco/compression/mesh/mesh_sequential_decoder.cc
+++ b/src/draco/compression/mesh/mesh_sequential_decoder.cc
@@ -96,7 +96,7 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
         }
         mesh()->AddFace(face);
       }
-    } else if (mesh()->num_points() < (1 << 21) &&
+    } else if (num_points < (1 << 21) &&
                bitstream_version() >= DRACO_BITSTREAM_VERSION(2, 2)) {
       // Decode indices as uint32_t.
       for (uint32_t i = 0; i < num_faces; ++i) {


### PR DESCRIPTION
num_points was retrieved from a wrong location causing incorrect branch to be taken during decoding for certain input models.