### PR TITLE
Avoid comparing bool using the < and > operator

### DIFF
--- a/src/draco/attributes/geometry_attribute.h
+++ b/src/draco/attributes/geometry_attribute.h
@@ -284,7 +284,8 @@ class GeometryAttribute {
 
       // Make sure the in_value fits within the range of values that OutT
       // is able to represent. Perform the check only for integral types.
-      if (std::is_integral<T>::value && std::is_integral<OutT>::value) {
+      if (!std::is_same<T, bool>::value && std::is_integral<T>::value &&
+          std::is_integral<OutT>::value) {
         static constexpr OutT kOutMin =
             std::is_signed<T>::value ? std::numeric_limits<OutT>::lowest() : 0;
         if (in_value < kOutMin || in_value > std::numeric_limits<OutT>::max()) {


### PR DESCRIPTION
There is no need to perform the check if T is of type bool, since it is guaranteed to fit in all other integral types.

This avoids triggering a C4804 warning in Visual Studio, ie. `unsafe use of type 'bool' in operation`