### PR TITLE
fix M_PI error on MSVC

### DIFF
--- a/src/draco/scene/light.cc
+++ b/src/draco/scene/light.cc
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#endif
+
 #include "draco/scene/light.h"
 
 #ifdef DRACO_TRANSCODER_SUPPORTED


### PR DESCRIPTION
Without the macro `_USE_MATH_DEFINES`, MSVC will emit a compile error on M_PI