### PR TITLE
WIP: support writing to cwd on Windows.

### DIFF
--- a/src/draco/io/file_writer_utils_test.cc
+++ b/src/draco/io/file_writer_utils_test.cc
@@ -28,6 +28,7 @@ TEST(FileWriterUtilsTest, SplitPathPrivateWindows) {
 
 TEST(FileWriterUtilsTest, DirectoryExistsTest) {
   ASSERT_TRUE(DirectoryExists(GetTestTempDir()));
+  ASSERT_TRUE(DirectoryExists("."));
   ASSERT_FALSE(DirectoryExists("fake/test/subdir"));
 }
 


### PR DESCRIPTION
I think stat() is failing for "." on Windows. This first patch updates a test that will hopefully catch the problem.