### PR TITLE
README: Explain better that example turns WASM off

### DIFF
--- a/javascript/example/README.md
+++ b/javascript/example/README.md
@@ -45,7 +45,7 @@ Create DracoLoader by setting the decoder type:
 // the static URL.
 THREE.DRACOLoader.setDecoderPath('./path/to/decoder/');
 
-// (Optional) Use JS decoder (defaults to WebAssembly if supported).
+// (Optional) Force non-WebAssembly JS decoder (without this line, WebAssembly is the default if supported).
 THREE.DRACOLoader.setDecoderConfig({type: 'js'});
 
 // (Optional) Pre-fetch decoder source files (defaults to load on demand).


### PR DESCRIPTION
The existing wording could be interpreted as that line implementing `defaults to WebAssembly if supported`, when in fact it is meant that it turns it off.