### PR TITLE
Fix signed/unsigned mismatch in decoder_buffer.h

### DIFF
--- a/src/draco/core/decoder_buffer.h
+++ b/src/draco/core/decoder_buffer.h
@@ -162,7 +162,7 @@ class DecoderBuffer {
         return false;
       }
       uint32_t value = 0;
-      for (int32_t bit = 0; bit < nbits; ++bit) {
+      for (int32_t bit = 0; bit < static_cast<int32_t>(nbits); ++bit) {
         value |= GetBit() << bit;
       }
       *x = value;


### PR DESCRIPTION
Fixed warning regarding comparing a signed variable `bit` with unsigned `nbits`.

The value `nbits` is checked to be less then or equal to 32 in the rows above, which prevents overflow when casting to a signed type.