### PR TITLE
Add <cstdint> include to draco file_utils.h to fix GCC13 build failure.

### DIFF
--- a/src/draco/io/file_utils.h
+++ b/src/draco/io/file_utils.h
@@ -15,6 +15,7 @@
 #ifndef DRACO_IO_FILE_UTILS_H_
 #define DRACO_IO_FILE_UTILS_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This was causing failure to compile on GCC 13.