### PR TITLE
wasm example: add back config option for DracoDecoderModule

### DIFF
--- a/javascript/time_draco_decode.html
+++ b/javascript/time_draco_decode.html
@@ -51,7 +51,7 @@ function createDecoderModule() {
 
   // draco_decoder.js or draco_wasm_wrapper.js must be loaded before
   // DracoModule is created.
-  DracoDecoderModule({}).then((module) => {
+  DracoDecoderModule(dracoDecoderType).then((module) => {
     decoderModule = module;
     enableButtons();
   });


### PR DESCRIPTION
after it was removed a few years ago in the update to 1.4.0