### PR TITLE
Fix #if priority for ftell

### DIFF
--- a/src/draco/io/stdio_file_reader.cc
+++ b/src/draco/io/stdio_file_reader.cc
@@ -87,10 +87,10 @@ size_t StdioFileReader::GetFileSize() {
     return false;
   }
 
-#if _FILE_OFFSET_BITS == 64
-  const size_t file_size = static_cast<size_t>(ftello(file_));
-#elif defined _WIN64
+#if defined _WIN64
   const size_t file_size = static_cast<size_t>(_ftelli64(file_));
+#elif _FILE_OFFSET_BITS == 64
+  const size_t file_size = static_cast<size_t>(ftello(file_));
 #else
   const size_t file_size = static_cast<size_t>(ftell(file_));
 #endif


### PR DESCRIPTION
ftello is not defined on windows, but apparently `_FILE_OFFSET_BITS` is, swap the if cases to detect windows first.
Using the native LLVM+clang toolchain:
```
> clang --version
clang version 15.0.7
Target: x86_64-pc-windows-msvc
Thread model: posix
```