### PR TITLE
Added a toolchain configuration to build for tvos

### DIFF
--- a/cmake/toolchains/arm64-tvos.cmake
+++ b/cmake/toolchains/arm64-tvos.cmake
@@ -1,0 +1,28 @@
+# Copyright 2021 The Draco Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(DRACO_CMAKE_TOOLCHAINS_ARM64_TVOS_CMAKE_)
+  return()
+endif()
+set(DRACO_CMAKE_TOOLCHAINS_ARM64_TVOS_CMAKE_ 1)
+
+if(XCODE)
+  message(FATAL_ERROR "This toolchain does not support Xcode.")
+endif()
+
+set(CMAKE_SYSTEM_PROCESSOR "arm64")
+set(CMAKE_OSX_ARCHITECTURES "arm64")
+set(CMAKE_OSX_SDK "appletvos")
+
+include("${CMAKE_CURRENT_LIST_DIR}/arm-ios-common.cmake")


### PR DESCRIPTION
I needed a tvos build to go with ios, but the draco project doesn't seem to have one, so I've added one!

I'm a CMAKE newbie, so if anything is wrong, please correct it!

I use this exactly the same way I build ios (I need static libs);
`cmake ../ -DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=ON -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/arm64-ios.cmake`

But with this new toolchain
`cmake ../ -DEMSCRIPTEN_GENERATE_BITCODE_STATIC_LIBRARIES=ON -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/arm64-tvos.cmake`