### PR TITLE
Fix build warning with clang 12

### DIFF
--- a/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc
+++ b/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc
@@ -108,7 +108,6 @@ std::unique_ptr<PointsSequencer>
 MeshEdgebreakerDecoderImpl<TraversalDecoder>::CreateVertexTraversalSequencer(
     MeshAttributeIndicesEncodingData *encoding_data) {
   typedef typename TraverserT::TraversalObserver AttObserver;
-  typedef typename TraverserT::CornerTable CornerTable;
 
   const Mesh *mesh = decoder_->mesh();
   std::unique_ptr<MeshTraversalSequencer<TraverserT>> traversal_sequencer(

--- a/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc
+++ b/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc
@@ -920,7 +920,7 @@ int MeshEdgebreakerDecoderImpl<TraversalDecoder>::DecodeConnectivity(
   int num_vertices = corner_table_->num_vertices();
   // If any vertex was marked as isolated, we want to remove it from the corner
   // table to ensure that all vertices in range <0, num_vertices> are valid.
-  for (const VertexIndex invalid_vert : invalid_vertices) {
+  for (const VertexIndex& invalid_vert : invalid_vertices) {
     // Find the last valid vertex and swap it with the isolated vertex.
     VertexIndex src_vert(num_vertices - 1);
     while (corner_table_->LeftMostCorner(src_vert) == kInvalidCornerIndex) {

--- a/src/draco/compression/mesh/mesh_edgebreaker_encoder_impl.cc
+++ b/src/draco/compression/mesh/mesh_edgebreaker_encoder_impl.cc
@@ -94,7 +94,6 @@ std::unique_ptr<PointsSequencer>
 MeshEdgebreakerEncoderImpl<TraversalEncoder>::CreateVertexTraversalSequencer(
     MeshAttributeIndicesEncodingData *encoding_data) {
   typedef typename TraverserT::TraversalObserver AttObserver;
-  typedef typename TraverserT::CornerTable CornerTable;
 
   std::unique_ptr<MeshTraversalSequencer<TraverserT>> traversal_sequencer(
       new MeshTraversalSequencer<TraverserT>(mesh_, encoding_data));


### PR DESCRIPTION
Fix the following warnings, to make clang happy.

* range-loop-construct
```
D:/CODE/draco/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc:923:26: error: loop variable 'invalid_vert' creates a copy from type 'const draco::VertexIndex' (aka 'const IndexType<unsigned int, draco::VertexIndex_tag_type_>') [-Werror,-Wrange-loop-construct]
  for (const VertexIndex invalid_vert : invalid_vertices) {
```

* unused-local-typedef
```
D:/CODE/draco/src/draco/compression/mesh/mesh_edgebreaker_encoder_impl.cc:97:44: error: unused typedef 'CornerTable' [-Werror,-Wunused-local-typedef]
  typedef typename TraverserT::CornerTable CornerTable;

D:/CODE/draco/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc:111:44: error: unused typedef 'CornerTable' [-Werror,-Wunused-local-typedef]
  typedef typename TraverserT::CornerTable CornerTable;
```