### PR TITLE
Install CMake configuration files into ${CMAKE_INSTALL_LIBDIR}/cmake/draco

### DIFF
--- a/cmake/draco_install.cmake
+++ b/cmake/draco_install.cmake
@@ -97,7 +97,7 @@ macro(draco_setup_install_target)
   configure_package_config_file(
     "${draco_root}/cmake/draco-config.cmake.template"
     "${draco_build}/draco-config.cmake"
-    INSTALL_DESTINATION "${data_path}/cmake/draco")
+    INSTALL_DESTINATION "${libs_path}/cmake/draco")
 
   write_basic_package_version_file(
     "${draco_build}/draco-config-version.cmake"
@@ -113,9 +113,9 @@ macro(draco_setup_install_target)
     EXPORT dracoExport
     NAMESPACE draco::
     FILE draco-targets.cmake
-    DESTINATION "${data_path}/cmake/draco")
+    DESTINATION "${libs_path}/cmake/draco")
 
   install(FILES "${draco_build}/draco-config.cmake"
                 "${draco_build}/draco-config-version.cmake"
-          DESTINATION "${data_path}/cmake/draco")
+          DESTINATION "${libs_path}/cmake/draco")
 endmacro()


### PR DESCRIPTION
It may be more proper to install cmake config files into `${CMAKE_INSTALL_LIBDIR}/cmake/draco` to follow the current pratice, which is adopted by CMake documentation example and many c++ libraries.

Ref: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8111
https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html
https://github.com/google/re2/blob/11073deb73b3d01018308863c0bcdfd0d51d3e70/CMakeLists.txt#L202-L204