### PR TITLE
Add /build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/_site
+/build


### PR DESCRIPTION
When building with cmake, running it inside /build folder is a quite popular way of doing it. Ignore this /build folder from git is quite convenient when running cmake in such way!