### PR TITLE
Fix -Wdeprecated-this-capture warnings

### DIFF
--- a/src/draco/io/ply_property_reader.h
+++ b/src/draco/io/ply_property_reader.h
@@ -31,42 +31,42 @@ class PlyPropertyReader {
     // Find the suitable function for converting values.
     switch (property->data_type()) {
       case DT_UINT8:
-        convert_value_func_ = [=](int val_id) {
+        convert_value_func_ = [this](int val_id) {
           return this->ConvertValue<uint8_t>(val_id);
         };
         break;
       case DT_INT8:
-        convert_value_func_ = [=](int val_id) {
+        convert_value_func_ = [this](int val_id) {
           return this->ConvertValue<int8_t>(val_id);
         };
         break;
       case DT_UINT16:
-        convert_value_func_ = [=](int val_id) {
+        convert_value_func_ = [this](int val_id) {
           return this->ConvertValue<uint16_t>(val_id);
         };
         break;
       case DT_INT16:
-        convert_value_func_ = [=](int val_id) {
+        convert_value_func_ = [this](int val_id) {
           return this->ConvertValue<int16_t>(val_id);
         };
         break;
       case DT_UINT32:
-        convert_value_func_ = [=](int val_id) {
+        convert_value_func_ = [this](int val_id) {
           return this->ConvertValue<uint32_t>(val_id);
         };
         break;
       case DT_INT32:
-        convert_value_func_ = [=](int val_id) {
+        convert_value_func_ = [this](int val_id) {
           return this->ConvertValue<int32_t>(val_id);
         };
         break;
       case DT_FLOAT32:
-        convert_value_func_ = [=](int val_id) {
+        convert_value_func_ = [this](int val_id) {
           return this->ConvertValue<float>(val_id);
         };
         break;
       case DT_FLOAT64:
-        convert_value_func_ = [=](int val_id) {
+        convert_value_func_ = [this](int val_id) {
           return this->ConvertValue<double>(val_id);
         };
         break;

--- a/src/draco/io/ply_property_writer.h
+++ b/src/draco/io/ply_property_writer.h
@@ -30,42 +30,42 @@ class PlyPropertyWriter {
     // Find the suitable function for converting values.
     switch (property->data_type()) {
       case DT_UINT8:
-        convert_value_func_ = [=](WriteTypeT val) {
+        convert_value_func_ = [this](WriteTypeT val) {
           return this->ConvertValue<uint8_t>(val);
         };
         break;
       case DT_INT8:
-        convert_value_func_ = [=](WriteTypeT val) {
+        convert_value_func_ = [this](WriteTypeT val) {
           return this->ConvertValue<int8_t>(val);
         };
         break;
       case DT_UINT16:
-        convert_value_func_ = [=](WriteTypeT val) {
+        convert_value_func_ = [this](WriteTypeT val) {
           return this->ConvertValue<uint16_t>(val);
         };
         break;
       case DT_INT16:
-        convert_value_func_ = [=](WriteTypeT val) {
+        convert_value_func_ = [this](WriteTypeT val) {
           return this->ConvertValue<int16_t>(val);
         };
         break;
       case DT_UINT32:
-        convert_value_func_ = [=](WriteTypeT val) {
+        convert_value_func_ = [this](WriteTypeT val) {
           return this->ConvertValue<uint32_t>(val);
         };
         break;
       case DT_INT32:
-        convert_value_func_ = [=](WriteTypeT val) {
+        convert_value_func_ = [this](WriteTypeT val) {
           return this->ConvertValue<int32_t>(val);
         };
         break;
       case DT_FLOAT32:
-        convert_value_func_ = [=](WriteTypeT val) {
+        convert_value_func_ = [this](WriteTypeT val) {
           return this->ConvertValue<float>(val);
         };
         break;
       case DT_FLOAT64:
-        convert_value_func_ = [=](WriteTypeT val) {
+        convert_value_func_ = [this](WriteTypeT val) {
           return this->ConvertValue<double>(val);
         };
         break;


### PR DESCRIPTION
C++20 deprecated implicit capturing of `this` in lambdas when capturing with `[=]`.
Therefore this PR replaces these implicit captures by explicit ones.
(This is backwards-compatible with earlier C++ standards that support lambdas.)