### PR TITLE
Add support for per-face texture coordinates in the PLY decoder.

### DIFF
--- a/src/draco/io/ply_decoder.h
+++ b/src/draco/io/ply_decoder.h
@@ -48,7 +48,12 @@ class PlyDecoder {
   DecoderBuffer *buffer() { return &buffer_; }
 
  private:
-  Status DecodeFaceData(const PlyElement *face_element);
+  Status DecodeFaceData(const PlyElement *face_element,
+                        const int num_vertices);
+  Status DecodeFaceTexCoordData(
+      const PlyElement *face_element,
+      const PlyProperty *vertex_indices,
+      const int num_vertices);
   Status DecodeVertexData(const PlyElement *vertex_element);
 
   template <typename DataTypeT>

--- a/src/draco/io/ply_decoder_test.cc
+++ b/src/draco/io/ply_decoder_test.cc
@@ -77,6 +77,21 @@ TEST_F(PlyDecoderTest, TestPlyNormals) {
   ASSERT_EQ(att->size(), 6);  // 6 unique normal values.
 }
 
+TEST_F(PlyDecoderTest, TestPlyTexCoords) {
+  const std::string file_name = "cube_att.ply";
+  std::unique_ptr<Mesh> mesh;
+  test_decoding(file_name, 12, 3 * 8, &mesh);
+  ASSERT_NE(mesh, nullptr);
+  const int att_id = mesh->GetNamedAttributeId(GeometryAttribute::TEX_COORD);
+  ASSERT_GE(att_id, 0);
+  const PointAttribute *const att = mesh->attribute(att_id);
+  ASSERT_EQ(att->size(), 4);  // 4 unique texture coordinate values.
+  float vertex_0_tex_coord[2];
+  att->GetValue(AttributeValueIndex(0), vertex_0_tex_coord);
+  ASSERT_EQ(vertex_0_tex_coord[0], 0);
+  ASSERT_EQ(vertex_0_tex_coord[1], 1);
+}
+
 TEST_F(PlyDecoderTest, TestPlyDecodingAll) {
   // test if we can read all ply that are currently in test folder.
   test_decoding("bun_zipper.ply");


### PR DESCRIPTION
This PR adds support to the PlyDecoder for decoding texture coordinates from the `texcoord` property of the `face` element.

PLY files can support a single vertex with different texture coordinates per face. Since Draco expects texture coordinates to be stored per-vertex, this implementation chooses the last set of texture coordinates found for each vertex. For many users this should not be an issue. Where it is a problem, it's no worse than not having texture coordinate support at all.