### PR TITLE
add .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/doc" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    groups:
+      doc-gems-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@
 version: 2
 updates:
   - package-ecosystem: "bundler"
-    directory: "/doc" # Location of package manifests
+    directory: "/doc"
     schedule:
       interval: "monthly"
     groups:
@@ -11,4 +11,3 @@ updates:
         applies-to: "security-updates"
         patterns:
           - "*"
-


### PR DESCRIPTION
This attempts to group all security related fixes for docs/ gems into
one PR on a monthly basis.