### PR TITLE
Fix CMake when building as dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 set(draco_root "${CMAKE_CURRENT_SOURCE_DIR}")
 set(draco_src_root "${draco_root}/src/draco")
-set(draco_build "${CMAKE_BINARY_DIR}")
+set(draco_build "${CMAKE_CURRENT_BINARY_DIR}")
 
 if("${draco_root}" STREQUAL "${draco_build}")
   message(


### PR DESCRIPTION
When building draco as part of a larger project, draco_features.h gets misplaced (into the main output folder) and failed to be found by draco source file