### PR TITLE
feat: add arm64-simulator toolchain

### DIFF
--- a/cmake/toolchains/arm64-iossimulator.cmake
+++ b/cmake/toolchains/arm64-iossimulator.cmake
@@ -1,0 +1,28 @@
+# Copyright 2021 The Draco Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+if(DRACO_CMAKE_TOOLCHAINS_ARM64_IOS_CMAKE_)
+  return()
+endif()
+set(DRACO_CMAKE_TOOLCHAINS_ARM64_IOS_CMAKE_ 1)
+
+if(XCODE)
+  message(FATAL_ERROR "This toolchain does not support Xcode.")
+endif()
+
+set(CMAKE_SYSTEM_PROCESSOR "arm64")
+set(CMAKE_OSX_ARCHITECTURES "arm64")
+set(CMAKE_OSX_SDK "iphonesimulator")
+
+include("${CMAKE_CURRENT_LIST_DIR}/arm-ios-common.cmake")


### PR DESCRIPTION
Hey, 

As Apple is now shifting towards ARM Macs, I've added toolchain for ARM iossimulator. 

Tested it by building Draco xcframework for ARM (iphoneos) + x86 + arm64 (simulator)