### PR TITLE
gltf_utils.h: add a missing <cstdint>

### DIFF
--- a/src/draco/io/gltf_utils.h
+++ b/src/draco/io/gltf_utils.h
@@ -21,6 +21,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <cstdint>
 
 namespace draco {
 


### PR DESCRIPTION
Fixes build error:
```
[ 46%] Building CXX object CMakeFiles/draco_io.dir/src/draco/io/gltf_utils.cc.o
/opt/local/bin/ccache /opt/local/bin/g++-mp-14 -DDRACO_CMAKE=1 -DDRACO_FLAGS_SRCDIR=\"/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_archivers_draco/draco/work/draco-1.5.7\" -DDRACO_FLAGS_TMPDIR=\"/tmp\" -I/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_archivers_draco/draco/work/draco-1.5.7 -I/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_archivers_draco/draco/work/draco-1.5.7/src -I/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_archivers_draco/draco/work/build -I/opt/local/include/eigen3 -I/opt/local/include/ghc -I/opt/local/include -pipe -Os -fpermissive -DNDEBUG -isystem/opt/local/include/LegacySupport -I/opt/local/include -D_GLIBCXX_USE_CXX11_ABI=0 -std=gnu++17 -arch ppc -mmacosx-version-min=10.6 -fPIC -Wno-deprecated-declarations -MD -MT CMakeFiles/draco_io.dir/src/draco/io/gltf_utils.cc.o -MF CMakeFiles/draco_io.dir/src/draco/io/gltf_utils.cc.o.d -o CMakeFiles/draco_io.dir/src/draco/io/gltf_utils.cc.o -c /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_archivers_draco/draco/work/draco-1.5.7/src/draco/io/gltf_utils.cc
In file included from /opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_archivers_draco/draco/work/draco-1.5.7/src/draco/io/gltf_utils.cc:15:
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_archivers_draco/draco/work/draco-1.5.7/src/draco/io/gltf_utils.h:35:29: error: expected ')' before 'value'
   35 |   explicit GltfValue(uint8_t value)
      |                     ~       ^~~~~~
      |                             )
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_archivers_draco/draco/work/draco-1.5.7/src/draco/io/gltf_utils.h:41:30: error: expected ')' before 'value'
   41 |   explicit GltfValue(uint16_t value)
      |                     ~        ^~~~~~
      |                              )
/opt/local/var/macports/build/_opt_PPCSnowLeopardPorts_archivers_draco/draco/work/draco-1.5.7/src/draco/io/gltf_utils.h:44:30: error: expected ')' before 'value'
   44 |   explicit GltfValue(uint32_t value)
      |                     ~        ^~~~~~
      |                              )
make[2]: *** [CMakeFiles/draco_io.dir/src/draco/io/gltf_utils.cc.o] Error 1
```