### PR TITLE
Add missing `include <algorithm>`

### DIFF
--- a/src/draco/io/ply_reader.cc
+++ b/src/draco/io/ply_reader.cc
@@ -14,6 +14,7 @@
 //
 #include "draco/io/ply_reader.h"
 
+#include <algorithm>
 #include <array>
 #include <regex>
 


### PR DESCRIPTION
When building with `CMAKE_CXX_STANDARD=23` and Apple clang 16.0.0 the build fails in `ply_reader.cc` because of `error: no member named 'all_of' in namespace 'std'`

This PR adds the missing `#include <algorithm>`