### PR TITLE
gltf_utils.h: add missing <cstdint>

### DIFF
--- a/src/draco/io/gltf_utils.h
+++ b/src/draco/io/gltf_utils.h
@@ -18,6 +18,7 @@
 #include "draco/draco_features.h"
 
 #ifdef DRACO_TRANSCODER_SUPPORTED
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Fixes `-DDRACO_TRANSCODER_SUPPORTED=1` build with newer versions of gcc
(reproduced with 13 in the github workflow & 14 locally):

```
In file included from src/draco/io/gltf_utils.cc:15:
src/draco/io/gltf_utils.h:35:29: error: expected ')' before 'value'
   35 |   explicit GltfValue(uint8_t value)
      |                     ~       ^~~~~~
      |                             )
src/draco/io/gltf_utils.h:41:30: error: expected ')' before 'value'
   41 |   explicit GltfValue(uint16_t value)
      |                     ~        ^~~~~~
      |                              )
src/draco/io/gltf_utils.h:44:30: error: expected ')' before 'value'
   44 |   explicit GltfValue(uint32_t value)
      |                     ~        ^~~~~~
      |                              )
```
