### PR TITLE
ci.yml: update windows image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,13 +296,14 @@ jobs:
             os: macos-latest
             test_command: python3 test.py -v -t -G Xcode
 
-          - test_name: windows-make
-            os: windows-latest
-            test_command: python3 test.py -v -G "MinGW Makefiles"
-          - test_name: windows-make-with-transcoder
-            os: windows-latest
-            test_command: python3 test.py -v -t -G "MinGW Makefiles"
-            shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail {0}
+          # TODO: These fail when attempting to run install_check.exe with exit
+          # code 0xC0000139 (DLL entry point not found).
+          # - test_name: windows-make
+          #   os: windows-latest
+          #   test_command: python3 test.py -v -G "MinGW Makefiles"
+          # - test_name: windows-make-with-transcoder
+          #   os: windows-latest
+          #   test_command: python3 test.py -v -t -G "MinGW Makefiles"
 
           - test_name: windows-msvc
             os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Run tests
         if: runner.os == 'Windows'
-        shell: msys2 {0}
+        shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail {0}
         run: ${{ matrix.draco_test_command }}
         working-directory: ./_gh_build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,9 @@ jobs:
         working-directory: ./_gh_build
 
       - name: Run tests
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        if: runner.os != 'Windows'
         shell: bash
         run: ${{ matrix.draco_test_command }}
         working-directory: ./_gh_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,10 @@ jobs:
       - name: Run tests
         if: runner.os == 'Windows'
         shell: msys2 {0}
+        run: ${{ matrix.draco_test_command }}
+        working-directory: ./_gh_build
+
+      - name: Run tests
         if: runner.os != 'Windows'
         shell: bash
         run: ${{ matrix.draco_test_command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,7 @@ jobs:
           - test_name: windows-make-with-transcoder
             os: windows-latest
             test_command: python3 test.py -v -t -G "MinGW Makefiles"
+            shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail {0}
 
           - test_name: windows-msvc
             os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,18 +148,18 @@ jobs:
             draco_test_command: ./draco_tests
 
           - test_name: windows-msvc-release-shared
-            os: windows-2019
+            os: windows-latest
             cmake_configure_command: |-
-              cmake .. -G "Visual Studio 16 2019" \
+              cmake .. -G "Visual Studio 17 2022" \
                 -DBUILD_SHARED_LIBS=ON \
                 -DCMAKE_CONFIGURATION_TYPES=Release \
                 -DDRACO_TESTS=ON
             cmake_build_command: cmake --build . --config Release -- -m:2
             draco_test_command: Release/draco_tests
           - test_name: windows-msvc-release-shared-with-transcoder
-            os: windows-2019
+            os: windows-latest
             cmake_configure_command: |-
-              cmake .. -G "Visual Studio 16 2019" \
+              cmake .. -G "Visual Studio 17 2022" \
                 -DBUILD_SHARED_LIBS=ON \
                 -DCMAKE_CONFIGURATION_TYPES=Release \
                 -DDRACO_TESTS=ON \
@@ -168,18 +168,18 @@ jobs:
             draco_test_command: Release/draco_tests
 
           - test_name: windows-msvc-release-static
-            os: windows-2019
+            os: windows-latest
             cmake_configure_command: |-
-              cmake .. -G "Visual Studio 16 2019" \
+              cmake .. -G "Visual Studio 17 2022" \
                 -DBUILD_SHARED_LIBS=OFF \
                 -DCMAKE_CONFIGURATION_TYPES=Release \
                 -DDRACO_TESTS=ON
             cmake_build_command: cmake --build . --config Release -- -m:2
             draco_test_command: Release/draco_tests
           - test_name: windows-msvc-release-static-with-transcoder
-            os: windows-2019
+            os: windows-latest
             cmake_configure_command: |-
-              cmake .. -G "Visual Studio 16 2019" \
+              cmake .. -G "Visual Studio 17 2022" \
                 -DBUILD_SHARED_LIBS=OFF \
                 -DCMAKE_CONFIGURATION_TYPES=Release \
                 -DDRACO_TESTS=ON \
@@ -188,7 +188,7 @@ jobs:
             draco_test_command: Release/draco_tests
 
           - test_name: windows-make-release-shared
-            os: windows-2019
+            os: windows-latest
             cmake_configure_command: |-
               cmake .. -G "MinGW Makefiles" \
                 -DBUILD_SHARED_LIBS=ON \
@@ -199,7 +199,7 @@ jobs:
             cmake_build_command: cmake --build . -- -j2
             draco_test_command: ./draco_tests
           - test_name: windows-make-release-shared-with-transcoder
-            os: windows-2019
+            os: windows-latest
             cmake_configure_command: |-
               cmake .. -G "MinGW Makefiles" \
                 -DBUILD_SHARED_LIBS=ON \
@@ -212,7 +212,7 @@ jobs:
             draco_test_command: ./draco_tests
 
           - test_name: windows-make-release-static
-            os: windows-2019
+            os: windows-latest
             cmake_configure_command: |-
               cmake .. -G "MinGW Makefiles" \
                 -DBUILD_SHARED_LIBS=OFF \
@@ -223,7 +223,7 @@ jobs:
             cmake_build_command: cmake --build . -- -j2
             draco_test_command: ./draco_tests
           - test_name: windows-make-release-static-with-transcoder
-            os: windows-2019
+            os: windows-latest
             cmake_configure_command: |-
               cmake .. -G "MinGW Makefiles" \
                 -DBUILD_SHARED_LIBS=OFF \
@@ -290,18 +290,18 @@ jobs:
             test_command: python3 test.py -v -t -G Xcode
 
           - test_name: windows-make
-            os: windows-2019
+            os: windows-latest
             test_command: python3 test.py -v -G "MinGW Makefiles"
           - test_name: windows-make-with-transcoder
-            os: windows-2019
+            os: windows-latest
             test_command: python3 test.py -v -t -G "MinGW Makefiles"
 
           - test_name: windows-msvc
-            os: windows-2019
-            test_command: python3 test.py -v -G "Visual Studio 16 2019"
+            os: windows-latest
+            test_command: python3 test.py -v -G "Visual Studio 17 2022"
           - test_name: windows-msvc-with-transcoder
-            os: windows-2019
-            test_command: python3 test.py -v -t -G "Visual Studio 16 2019"
+            os: windows-latest
+            test_command: python3 test.py -v -t -G "Visual Studio 17 2022"
 
     name: install-test-${{ matrix.test_name }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,14 +296,12 @@ jobs:
             os: macos-latest
             test_command: python3 test.py -v -t -G Xcode
 
-          # TODO: These fail when attempting to run install_check.exe with exit
-          # code 0xC0000139 (DLL entry point not found).
-          # - test_name: windows-make
-          #   os: windows-latest
-          #   test_command: python3 test.py -v -G "MinGW Makefiles"
-          # - test_name: windows-make-with-transcoder
-          #   os: windows-latest
-          #   test_command: python3 test.py -v -t -G "MinGW Makefiles"
+          - test_name: windows-make
+            os: windows-latest
+            test_command: python3 test.py -v -G "MinGW Makefiles"
+          - test_name: windows-make-with-transcoder
+            os: windows-latest
+            test_command: python3 test.py -v -t -G "MinGW Makefiles"
 
           - test_name: windows-msvc
             os: windows-latest
@@ -321,7 +319,16 @@ jobs:
         with:
           submodules: true
 
+      # Note msys bash is only needed for the MinGW Makefiles builds, but it
+      # works for the MSVC builds as well.
       - name: Run src/draco/tools/install_test/test.py
+        if: runner.os == 'Windows'
+        shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail {0}
+        run: ${{ matrix.test_command }}
+        working-directory: ./src/draco/tools/install_test
+
+      - name: Run src/draco/tools/install_test/test.py
+        if: runner.os != 'Windows'
         shell: bash
         run: ${{ matrix.test_command }}
         working-directory: ./src/draco/tools/install_test


### PR DESCRIPTION
windows-2019 was removed on 2025-06-30, use windows-latest. windows-2022
(latest) and windows-2025 both include Visual Studio 2022 so there
should be limited maintenance when latest is switched.

The "MinGW Makefiles" builds needed an additional update to run under
the msys shell rather than gitbash (where the executables failed to
start).