### PR TITLE
Fix generating draco project files from a directory containing special characters

### DIFF
--- a/cmake/draco_install.cmake
+++ b/cmake/draco_install.cmake
@@ -31,15 +31,14 @@ macro(draco_setup_install_target)
 
     foreach(file ${draco_sources})
       if(file MATCHES "h$")
-        list(APPEND draco_api_includes ${file})
+        # Strip $draco_src_root from the file paths: we need to install relative to
+        # $include_directory.
+        file(RELATIVE_PATH relative_file ${draco_src_root} ${file})
+        list(APPEND draco_api_includes ${relative_file})
       endif()
     endforeach()
 
     list(REMOVE_DUPLICATES draco_api_includes)
-
-    # Strip $draco_src_root from the file paths: we need to install relative to
-    # $include_directory.
-    list(TRANSFORM draco_api_includes REPLACE "${draco_src_root}/" "")
 
     foreach(draco_api_include ${draco_api_includes})
       get_filename_component(file_directory ${draco_api_include} DIRECTORY)


### PR DESCRIPTION
If you try to generate draco project files from a directory containing any regex special characters cmake will fail.

In my case, draco is inside a directory called "c++" and, because "+" is a regex special character, cmake fails to generate the project files with the following error:

```
$ cmake ..
RegularExpression::compile(): Nested *?+.
RegularExpression::compile(): Error in compile.
CMake Error at cmake/draco_install.cmake:42 (list):
  list sub-command TRANSFORM, action REPLACE: Failed to compile regex
  "C:/repos/c++/draco/src/draco/".
Call Stack (most recent call first):
  CMakeLists.txt:1152 (draco_setup_install_target)
```

As you can see, the error occurs at line _42_ of _cmake/draco_install.cmake_:
https://github.com/google/draco/blob/931498aefb50fec176d5f091a6e291f3e12987ef/cmake/draco_install.cmake#L42
As per the [cmake documentation](https://cmake.org/cmake/help/v3.12/command/list.html?highlight=list#index-3-command:string), the _REPLACE_ action of the _TRANSFORM_ subcommand expects a regular expression as its first argument, in our case, this is the `${draco_src_root}` variable containing the project's path.

The problem is that the code assumes that the directory path is a regex therefore it must not contain any special characters.

The solution is simple, replace the faulty list transform command by a directory-aware alternative. I choose the _file RELATIVE_PATH_ command:
https://github.com/google/draco/blob/7577ec06a48b0791c55cc5b145b62a920acda2aa/cmake/draco_install.cmake#L36-L37
This command will compute the relative path to the files correctly, even if the directory contains special characters.

With these changes cmake will now correctly generate the project files:
```
$ cmake ..
-- Configuring done (6.5s)
-- Generating done (1.1s)
-- Build files have been written to: C:/repos/c++/draco/build_dir
```

Fixes https://github.com/google/draco/issues/1132


