### PR TITLE
fix: integer overflow in face/point count multiplications → heap overflow

### DIFF
--- a/src/draco/javascript/emscripten/decoder_webidl_wrapper.cc
+++ b/src/draco/javascript/emscripten/decoder_webidl_wrapper.cc
@@ -175,7 +175,11 @@ template <typename T>
 bool GetTrianglesArray(const draco::Mesh &m, const int out_size,
                        T *out_values) {
   const uint32_t num_faces = m.num_faces();
-  if (num_faces * 3 * sizeof(T) != out_size) {
+  // Check for integer overflow before size comparison.
+  const uint64_t required_size =
+      static_cast<uint64_t>(num_faces) * 3 * sizeof(T);
+  if (required_size > static_cast<uint64_t>(out_size) ||
+      static_cast<int>(required_size) != out_size) {
     return false;
   }
 

--- a/src/draco/maya/draco_maya_plugin.cc
+++ b/src/draco/maya/draco_maya_plugin.cc
@@ -20,6 +20,10 @@ namespace maya {
 static void decode_faces(std::unique_ptr<draco::Mesh> &drc_mesh,
                          Drc2PyMesh *out_mesh) {
   int num_faces = drc_mesh->num_faces();
+  // Check for integer overflow in num_faces * 3.
+  if (num_faces < 0 || static_cast<uint64_t>(num_faces) * 3 > SIZE_MAX / sizeof(int)) {
+    return;
+  }
   out_mesh->faces = new int[num_faces * 3];
   out_mesh->faces_num = num_faces;
   for (int i = 0; i < num_faces; i++) {

--- a/src/draco/unity/draco_unity_plugin.cc
+++ b/src/draco/unity/draco_unity_plugin.cc
@@ -236,6 +236,10 @@ bool EXPORT_API GetMeshIndices(const DracoMesh *mesh, DracoData **indices) {
     return false;
   }
   const Mesh *const m = static_cast<const Mesh *>(mesh->private_mesh);
+  // Check for integer overflow in num_faces * 3.
+  if (m->num_faces() > SIZE_MAX / 3 / sizeof(int)) {
+    return false;
+  }
   int *const temp_indices = new int[m->num_faces() * 3];
   for (draco::FaceIndex face_id(0); face_id < m->num_faces(); ++face_id) {
     const Mesh::Face &face = m->face(draco::FaceIndex(face_id));
@@ -328,6 +332,11 @@ int DecodeMeshForUnity(char *data, unsigned int length,
   unity_mesh->num_faces = in_mesh->num_faces();
   unity_mesh->num_vertices = in_mesh->num_points();
 
+  // Check for integer overflow in num_faces * 3.
+  if (in_mesh->num_faces() > SIZE_MAX / 3 / sizeof(int)) {
+    ReleaseUnityMesh(&unity_mesh);
+    return -4;
+  }
   unity_mesh->indices = new int[in_mesh->num_faces() * 3];
   for (draco::FaceIndex face_id(0); face_id < in_mesh->num_faces(); ++face_id) {
     const Mesh::Face &face = in_mesh->face(draco::FaceIndex(face_id));
@@ -336,6 +345,11 @@ int DecodeMeshForUnity(char *data, unsigned int length,
   }
 
   // TODO(draco-eng): Add other attributes.
+  // Check for integer overflow in num_points * components * sizeof(float).
+  if (in_mesh->num_points() > SIZE_MAX / 4 / sizeof(float)) {
+    ReleaseUnityMesh(&unity_mesh);
+    return -4;
+  }
   unity_mesh->position = new float[in_mesh->num_points() * 3];
   const auto pos_att =
       in_mesh->GetNamedAttribute(draco::GeometryAttribute::POSITION);


### PR DESCRIPTION
## Summary

Multiple locations in the Unity plugin, JavaScript/WASM decoder wrapper, and Maya plugin compute buffer sizes using `num_faces * 3` or `num_points * N` with attacker-controlled values from the Draco bitstream, without checking for integer overflow. When the product wraps to a small value, a tiny buffer is allocated and subsequent loops write the full (unwrapped) count of entries, causing a **heap buffer overflow**.

## Severity

**Critical** — Heap buffer overflow from crafted Draco files. Affects:
- Unity games loading user-provided 3D models
- Web applications using the Draco WASM decoder (Three.js, Google Model Viewer)
- Maya plugin loading untrusted meshes

## Vulnerable Code

### 1. JavaScript/WASM Decoder (decoder_webidl_wrapper.cc:178)
```cpp
const uint32_t num_faces = m.num_faces();
if (num_faces * 3 * sizeof(T) != out_size) {  // Overflow breaks this check
```
On WASM32, `sizeof(T)=4`, so `357913942 * 3 * 4 = 4294967304` wraps to `8`. If `out_size=8`, the check passes and the loop writes ~1.4B entries into an 8-byte buffer.

### 2. Unity Plugin (draco_unity_plugin.cc:239, 335, 343, 358, 373, 393)
```cpp
int *const temp_indices = new int[m->num_faces() * 3];  // Overflow → tiny alloc
unity_mesh->position = new float[in_mesh->num_points() * 3];
unity_mesh->normal = new float[in_mesh->num_points() * 3];
unity_mesh->color = new float[in_mesh->num_points() * 4];
unity_mesh->texcoord = new float[in_mesh->num_points() * 2];
```

### 3. Maya Plugin (draco_maya_plugin.cc:23)
```cpp
out_mesh->faces = new int[num_faces * 3];  // Overflow → tiny alloc
```

## Trigger

`num_faces = 1431655766` (just over UINT32_MAX / 3):
- `1431655766 * 3 = 4294967298` → overflows 32-bit to `2`
- `new int[2]` allocates 8 bytes
- Loop writes `1431655766 * 3 = ~4.3 billion` entries → **heap overflow**

## Note

The **core decoder** (`mesh/corner_table.cc:63`) does have an overflow check for `num_faces * 3`. But the **binding/extraction layer** (Unity, WASM, Maya) where decoded data is copied to caller buffers has **no overflow protection**. Existing fuzz targets do not cover these code paths.

## Fix

Added overflow checks before each unchecked multiplication in the Unity, WASM, and Maya plugins.