### PR TITLE
fix: validate face vertex indices in sequential decoder to prevent OOB access

### DIFF
--- a/src/draco/compression/mesh/mesh_sequential_decoder.cc
+++ b/src/draco/compression/mesh/mesh_sequential_decoder.cc
@@ -125,6 +125,16 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
     }
   }
   point_cloud()->set_num_points(num_points);
+
+  // Validate that all face vertex indices are within [0, num_points).
+  for (draco::FaceIndex fi(0); fi < mesh()->num_faces(); ++fi) {
+    const auto &face = mesh()->face(fi);
+    for (int j = 0; j < 3; ++j) {
+      if (face[j].value() >= num_points) {
+        return false;
+      }
+    }
+  }
   return true;
 }
 


### PR DESCRIPTION
## Summary

The sequential mesh decoder reads face vertex indices from the Draco bitstream without validating that they fall within `[0, num_points)`. When a crafted Draco file contains out-of-range indices, attribute access via `GeometryAttribute::GetValue()` causes an **out-of-bounds heap read**.

## ASan Proof

```
==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 12 at 0x507000000540 thread T0
    #0 in memcpy
    #1 in draco::DataBuffer::Read (data_buffer.h:48)
    #2 in draco::GeometryAttribute::GetValue (geometry_attribute.h:138)

0x507000000540 is located 1128 bytes after 72-byte region [0x507000000090,0x5070000000d8)
```

A 72-byte attribute buffer (6 points × 12 bytes) was accessed at index 100 (offset 1200) — **1128 bytes past the end**.

## Root Cause

`mesh_sequential_decoder.cc` lines 74-125: all four index decoding paths (`uint8`, `uint16`, `uint32` varint, `uint32` direct) store indices from the stream into `face[j]` without checking `val < num_points`. The compressed index path (`DecodeAndDecompressIndices`) has the same issue.

## Impact

Any application that decodes attacker-provided `.drc` files is affected. The OOB read can leak heap data. Combined with attribute write operations (deduplication, transforms), this could potentially become an OOB write.

## Fix

Added a validation pass after decoding connectivity that checks all face vertex indices are within `[0, num_points)`.

## Separate from PR #1166

This is a **different root cause** from the integer overflow in PR #1166:
- PR #1166: `num_faces * 3` overflow → wrong allocation size → heap overflow (WRITE)
- This PR: unvalidated face indices → OOB attribute access (READ)