### PR TITLE
fix: integer overflow in CopyDataAsUint32 accessor.count * num_components

### DIFF
--- a/src/draco/io/gltf_decoder.cc
+++ b/src/draco/io/gltf_decoder.cc
@@ -167,7 +167,14 @@ StatusOr<std::vector<uint32_t>> CopyDataAsUint32(
       tinygltf::GetComponentSizeInBytes(accessor.componentType);
   const int num_components =
       TinyGltfUtils::GetNumComponentsForType(accessor.type);
-  const int num_elements = accessor.count * num_components;
+  // Check for integer overflow in accessor.count * num_components.
+  const int64_t num_elements_64 =
+      static_cast<int64_t>(accessor.count) * num_components;
+  if (num_elements_64 > std::numeric_limits<int>::max()) {
+    return Status(Status::DRACO_ERROR,
+                  "CopyDataAsUint32: accessor count overflow.");
+  }
+  const int num_elements = static_cast<int>(num_elements_64);
 
   std::vector<uint32_t> output;
   output.resize(num_elements);


### PR DESCRIPTION
## Summary

In `CopyDataAsUint32()` (gltf_decoder.cc:170), the computation `accessor.count * num_components` uses `int` arithmetic. When a crafted glTF file has a large `accessor.count` with a multi-component type (VEC2/VEC3/VEC4), the product overflows `int32`, causing `output.resize()` to receive a wrong value. The loop then writes `accessor.count * num_components` entries into the undersized buffer → **heap buffer overflow**.

## ASan Proof

```
poc_gltf_overflow.cc:31: warning: integer overflow in expression of type 'int' results in '-2147483647'

==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x502000000020
WRITE of size 4 at 0x502000000020 thread T0
    #0 in main poc_gltf_overflow.cc:74

0x502000000020 is located 0 bytes after 16-byte region [0x502000000010,0x502000000020)
```

## Trigger

`accessor.count = 715827883`, `num_components = 3` (VEC3):
- `715827883 * 3 = 2147483649` → overflows `int32` to `-2147483647`
- `output.resize(-2147483647)` → undefined behavior / tiny allocation
- Loop writes 2147483649 entries → heap overflow

## Fix

Use `int64_t` for the multiplication and check for overflow before casting to `int`.

## Separate from PRs #1166 and #1167

- PR #1166: `num_faces * 3` overflow in Unity/WASM/Maya binding layer
- PR #1167: unvalidated face vertex indices in sequential decoder
- **This PR**: `accessor.count * num_components` overflow in glTF decoder

Three separate root causes, three separate code paths.