### PR TITLE
Fix signed integer overflow in attribute decoder byte position counters

### DIFF
--- a/src/draco/attributes/attribute_quantization_transform.cc
+++ b/src/draco/attributes/attribute_quantization_transform.cc
@@ -80,8 +80,8 @@ bool AttributeQuantizationTransform::InverseTransformAttribute(
   const int num_components = target_attribute->num_components();
   const int entry_size = sizeof(float) * num_components;
   const std::unique_ptr<float[]> att_val(new float[num_components]);
-  int quant_val_id = 0;
-  int out_byte_pos = 0;
+  int64_t quant_val_id = 0;
+  int64_t out_byte_pos = 0;
   Dequantizer dequantizer;
   if (!dequantizer.Init(range_, max_quantized_value)) {
     return false;

--- a/src/draco/compression/attributes/kd_tree_attributes_decoder.cc
+++ b/src/draco/compression/attributes/kd_tree_attributes_decoder.cc
@@ -553,8 +553,8 @@ bool KdTreeAttributesDecoder::TransformAttributesToOriginalFormat() {
       const int num_components = att->num_components();
       const int entry_size = sizeof(float) * num_components;
       const std::unique_ptr<float[]> att_val(new float[num_components]);
-      int quant_val_id = 0;
-      int out_byte_pos = 0;
+      int64_t quant_val_id = 0;
+      int64_t out_byte_pos = 0;
       Dequantizer dequantizer;
       if (!dequantizer.Init(transform.range(), max_quantized_value)) {
         return false;

--- a/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_shared.h
+++ b/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_shared.h
@@ -56,9 +56,9 @@ inline bool ComputeParallelogramPrediction(
   if (vert_opp < data_entry_id && vert_next < data_entry_id &&
       vert_prev < data_entry_id) {
     // Apply the parallelogram prediction.
-    const int v_opp_off = vert_opp * num_components;
-    const int v_next_off = vert_next * num_components;
-    const int v_prev_off = vert_prev * num_components;
+    const int64_t v_opp_off = static_cast<int64_t>(vert_opp) * num_components;
+    const int64_t v_next_off = static_cast<int64_t>(vert_next) * num_components;
+    const int64_t v_prev_off = static_cast<int64_t>(vert_prev) * num_components;
     for (int c = 0; c < num_components; ++c) {
       const int64_t in_data_next_off = in_data[v_next_off + c];
       const int64_t in_data_prev_off = in_data[v_prev_off + c];

--- a/src/draco/compression/attributes/sequential_attribute_decoder.cc
+++ b/src/draco/compression/attributes/sequential_attribute_decoder.cc
@@ -103,7 +103,7 @@ bool SequentialAttributeDecoder::DecodeValues(
   const int entry_size = static_cast<int>(attribute_->byte_stride());
   std::unique_ptr<uint8_t[]> value_data_ptr(new uint8_t[entry_size]);
   uint8_t *const value_data = value_data_ptr.get();
-  int out_byte_pos = 0;
+  int64_t out_byte_pos = 0;
   // Decode raw attribute values in their original format.
   for (int i = 0; i < num_values; ++i) {
     if (!in_buffer->Decode(value_data, entry_size)) {

--- a/src/draco/compression/attributes/sequential_integer_attribute_decoder.cc
+++ b/src/draco/compression/attributes/sequential_integer_attribute_decoder.cc
@@ -218,8 +218,8 @@ void SequentialIntegerAttributeDecoder::StoreTypedValues(uint32_t num_values) {
   const std::unique_ptr<AttributeTypeT[]> att_val(
       new AttributeTypeT[num_components]);
   const int32_t *const portable_attribute_data = GetPortableAttributeData();
-  int val_id = 0;
-  int out_byte_pos = 0;
+  int64_t val_id = 0;
+  int64_t out_byte_pos = 0;
   for (uint32_t i = 0; i < num_values; ++i) {
     for (int c = 0; c < num_components; ++c) {
       const AttributeTypeT value =


### PR DESCRIPTION
## Summary

Several attribute decoder paths use `int` (32-bit signed) for byte position counters and value ID counters. When decoding meshes with a large number of vertices/attributes, these counters can exceed `INT32_MAX`, causing signed integer overflow (undefined behavior in C++). The overflowed negative values are then passed to `DataBuffer::Write()` as byte offsets, which performs `memcpy(data() + byte_pos, ...)` without bounds checking.

## Affected Code

| File | Variable | Type |
|------|----------|------|
| `sequential_integer_attribute_decoder.cc` | `out_byte_pos`, `val_id` | `int` → `int64_t` |
| `sequential_attribute_decoder.cc` | `out_byte_pos` | `int` → `int64_t` |
| `attribute_quantization_transform.cc` | `out_byte_pos`, `quant_val_id` | `int` → `int64_t` |
| `kd_tree_attributes_decoder.cc` | `out_byte_pos`, `quant_val_id` | `int` → `int64_t` |
| `mesh_prediction_scheme_parallelogram_shared.h` | `v_opp_off`, `v_next_off`, `v_prev_off` | `int` → `int64_t` |

## Fix

Widen all affected counters from `int`/`int32_t` to `int64_t` to prevent overflow for large meshes.

## Testing

Verified the fix compiles cleanly. Existing tests continue to pass.