### PR TITLE
Fix memory safety bugs in PLY, OBJ, and STL decoders

### DIFF
--- a/src/draco/io/obj_decoder.cc
+++ b/src/draco/io/obj_decoder.cc
@@ -447,7 +447,11 @@ bool ObjDecoder::ParseFace(Status *status) {
       for (int c = 0; c < 3; c++) {
         const PointIndex vert_id(3 * num_obj_faces_ + c);
         const int triangulated_index = Triangulate(t, c);
-        MapPointToVertexIndices(vert_id, indices[triangulated_index]);
+        if (!MapPointToVertexIndices(vert_id, indices[triangulated_index])) {
+          *status = Status(Status::DRACO_ERROR,
+                           "OBJ: negative index out of range");
+          return true;
+        }
         // Save info about new edges that will allow us to reconstruct polygons.
         if (added_edge_att_id_ >= 0) {
           const AttributeValueIndex avi(IsNewEdge(nt, t, c));
@@ -631,7 +635,7 @@ bool ObjDecoder::ParseVertexIndices(std::array<int32_t, 3> *out_indices) {
   return true;
 }
 
-void ObjDecoder::MapPointToVertexIndices(
+bool ObjDecoder::MapPointToVertexIndices(
     PointIndex vert_id, const std::array<int32_t, 3> &indices) {
   // Use face entries to store mapping between vertex and attribute indices
   // (positions, texture coordinates and normal indices).
@@ -643,6 +647,9 @@ void ObjDecoder::MapPointToVertexIndices(
     out_point_cloud_->attribute(pos_att_id_)
         ->SetPointMapEntry(vert_id, AttributeValueIndex(indices[0] - 1));
   } else if (indices[0] < 0) {
+    if (-indices[0] > num_positions_) {
+      return false;
+    }
     out_point_cloud_->attribute(pos_att_id_)
         ->SetPointMapEntry(vert_id,
                            AttributeValueIndex(num_positions_ + indices[0]));
@@ -653,6 +660,9 @@ void ObjDecoder::MapPointToVertexIndices(
       out_point_cloud_->attribute(tex_att_id_)
           ->SetPointMapEntry(vert_id, AttributeValueIndex(indices[1] - 1));
     } else if (indices[1] < 0) {
+      if (-indices[1] > num_tex_coords_) {
+        return false;
+      }
       out_point_cloud_->attribute(tex_att_id_)
           ->SetPointMapEntry(vert_id,
                              AttributeValueIndex(num_tex_coords_ + indices[1]));
@@ -669,6 +679,9 @@ void ObjDecoder::MapPointToVertexIndices(
       out_point_cloud_->attribute(norm_att_id_)
           ->SetPointMapEntry(vert_id, AttributeValueIndex(indices[2] - 1));
     } else if (indices[2] < 0) {
+      if (-indices[2] > num_normals_) {
+        return false;
+      }
       out_point_cloud_->attribute(norm_att_id_)
           ->SetPointMapEntry(vert_id,
                              AttributeValueIndex(num_normals_ + indices[2]));
@@ -691,6 +704,7 @@ void ObjDecoder::MapPointToVertexIndices(
     out_point_cloud_->attribute(sub_obj_att_id_)
         ->SetPointMapEntry(vert_id, AttributeValueIndex(last_sub_obj_id_));
   }
+  return true;
 }
 
 bool ObjDecoder::ParseMaterialFile(const std::string &file_name,

--- a/src/draco/io/obj_decoder.h
+++ b/src/draco/io/obj_decoder.h
@@ -87,7 +87,7 @@ class ObjDecoder {
 
   // Maps specified point index to the parsed vertex indices (triplet of
   // position, texture coordinate, and normal indices) .
-  void MapPointToVertexIndices(PointIndex vert_id,
+  bool MapPointToVertexIndices(PointIndex vert_id,
                                const std::array<int32_t, 3> &indices);
 
   // Parses material file definitions from a separate file.

--- a/src/draco/io/ply_reader.cc
+++ b/src/draco/io/ply_reader.cc
@@ -203,6 +203,10 @@ bool PlyReader::ParseElementData(DecoderBuffer *buffer, int element_index) {
         // Read and store the actual property data
         const int64_t num_bytes_to_read =
             prop.data_type_num_bytes() * num_entries;
+        if (num_entries < 0 ||
+            num_bytes_to_read > buffer->remaining_size()) {
+          return false;
+        }
         prop.data_.insert(prop.data_.end(), buffer->data_head(),
                           buffer->data_head() + num_bytes_to_read);
         buffer->Advance(num_bytes_to_read);

--- a/src/draco/io/stl_decoder.cc
+++ b/src/draco/io/stl_decoder.cc
@@ -41,9 +41,14 @@ StatusOr<std::unique_ptr<Mesh>> StlDecoder::DecodeFromBuffer(
     return Status(Status::IO_ERROR,
                   "Currently only binary STL files are supported.");
   }
+  if (buffer->remaining_size() < 80) {
+    return Status(Status::IO_ERROR, "STL: truncated header");
+  }
   buffer->Advance(80);
   uint32_t face_count;
-  buffer->Decode(&face_count, 4);
+  if (!buffer->Decode(&face_count, 4)) {
+    return Status(Status::IO_ERROR, "STL: truncated face count");
+  }
 
   TriangleSoupMeshBuilder builder;
   builder.Start(face_count);
@@ -55,9 +60,13 @@ StatusOr<std::unique_ptr<Mesh>> StlDecoder::DecodeFromBuffer(
 
   for (uint32_t i = 0; i < face_count; i++) {
     float data[48];
-    buffer->Decode(data, 48);
+    if (!buffer->Decode(data, 48)) {
+      return Status(Status::IO_ERROR, "STL: truncated face data");
+    }
     uint16_t unused;
-    buffer->Decode(&unused, 2);
+    if (!buffer->Decode(&unused, 2)) {
+      return Status(Status::IO_ERROR, "STL: truncated face data");
+    }
 
     builder.SetPerFaceAttributeValueForFace(
         norm_att_id, draco::FaceIndex(i),


### PR DESCRIPTION
## Summary

This PR fixes three memory safety vulnerabilities in Draco's mesh file decoders:

### 1. PLY heap-buffer-overflow in `ply_reader.cc`
In `ParseElementData`, the `num_entries` field of a list property is read from attacker-controlled input and used to compute `num_bytes_to_read` without validating against the remaining buffer size. A crafted PLY file with a large list count causes an out-of-bounds read past the input buffer via the `prop.data_.insert(... buffer->data_head() + num_bytes_to_read)` call.

**Fix:** Added bounds check that `num_entries >= 0` and `num_bytes_to_read <= buffer->remaining_size()` before the insert.

### 2. OBJ negative-index integer underflow in `obj_decoder.cc`
OBJ files support negative vertex indices (e.g., `f -1 -2 -3`) which are relative to the current vertex count. However, there was no validation that `|index| <= count`. A crafted file like `f -99999` with only a few vertices causes `num_positions_ + indices[0]` to underflow to a huge value, producing an out-of-range `AttributeValueIndex`.

**Fix:** Added validation that `-indices[i] <= num_positions_` (and similarly for tex coords and normals) for negative indices, returning an error status on violation.

### 3. STL unchecked Decode return values in `stl_decoder.cc`
In `DecodeFromBuffer`, all calls to `buffer->Decode()` had their boolean return values ignored. A truncated binary STL file causes reads past the end of the buffer without any error reporting.

**Fix:** Check return values of `Decode()` and `remaining_size()` before each buffer operation, returning descriptive `IO_ERROR` status on truncated input.

## Test plan
- [ ] Verify existing draco unit tests still pass
- [ ] Test with crafted PLY file containing oversized list count
- [ ] Test with OBJ file containing out-of-range negative indices (e.g., `f -99999`)
- [ ] Test with truncated binary STL file (< 84 bytes)