### PR TITLE
Add missing bounds check in RAnsDecoder::read_init

### DIFF
--- a/src/draco/compression/entropy/ans.h
+++ b/src/draco/compression/entropy/ans.h
@@ -441,6 +441,9 @@ class RAnsDecoder {
       ans_.buf_offset = offset - 3;
       ans_.state = mem_get_le24(buf + offset - 3) & 0x3FFFFF;
     } else if (x == 3) {
+      if (offset < 4) {
+        return 1;
+      }
       ans_.buf_offset = offset - 4;
       ans_.state = mem_get_le32(buf + offset - 4) & 0x3FFFFFFF;
     } else {


### PR DESCRIPTION
## Summary

- Add `offset < 4` guard to the `x == 3` branch in `RAnsDecoder::read_init()`
- The other branches (`x == 1`, `x == 2`) already validate their respective minimum offsets before reading
- Prevents reading before the start of the buffer when offset is less than 4

## Test plan

- [x] Verified the fix rejects small offsets in the x==3 path
- [x] Confirmed existing branches (x==0, x==1, x==2) are unchanged
- [x] Matches the guard pattern used by the legacy `ans_read_init` C function