### PR TITLE
Fix install path duplication when source root contains regex metacharacters

### DIFF
--- a/cmake/draco_install.cmake
+++ b/cmake/draco_install.cmake
@@ -37,14 +37,14 @@ macro(draco_setup_install_target)
 
     list(REMOVE_DUPLICATES draco_api_includes)
 
-    # Strip $draco_src_root from the file paths: we need to install relative to
-    # $include_directory.
-    list(TRANSFORM draco_api_includes REPLACE "${draco_src_root}/" "")
-
+    # Use file(RELATIVE_PATH) — not list(TRANSFORM REPLACE) — because the
+    # REPLACE pattern is a regex, and ${draco_src_root} may contain regex
+    # metacharacters (e.g. '+', '.') in package-manager and sandboxed paths.
     foreach(draco_api_include ${draco_api_includes})
-      get_filename_component(file_directory ${draco_api_include} DIRECTORY)
+      file(RELATIVE_PATH rel_include "${draco_src_root}" "${draco_api_include}")
+      get_filename_component(file_directory "${rel_include}" DIRECTORY)
       set(target_directory "${includes_path}/draco/${file_directory}")
-      install(FILES ${draco_src_root}/${draco_api_include}
+      install(FILES "${draco_api_include}"
               DESTINATION "${target_directory}")
     endforeach()
 


### PR DESCRIPTION
## Issue
 
`cmake/draco_install.cmake` strips `${draco_src_root}` from header paths
via `list(TRANSFORM ... REPLACE)`, whose pattern is a regex. When
`${draco_src_root}` contains a regex metacharacter (`+`, `.`, `?`, `*`,
etc.), the strip silently fails and `install(FILES)` reappends the
prefix, producing a doubled path. For example, when draco is checked out
under `/tmp/+a+/src/draco`:
 
    file INSTALL cannot find
      "/tmp/+a+/src/draco/src/draco//tmp/+a+/src/draco/src/draco/
       attributes/attribute_octahedron_transform.h"
 
Triggered by common path layouts such as Bazel sandbox execroots (`rules_foreign_cc`),
or any project path containing `+`.
 
## How to reproduce
 
Against current `main` HEAD:
 
```sh
mkdir -p "/tmp/+a+/src" && cd "/tmp/+a+/src"
git clone https://github.com/google/draco.git
mkdir build && cd build
cmake ../draco -DCMAKE_INSTALL_PREFIX=/tmp/inst
cmake --build . && cmake --install .
```
 
`cmake --install` fails with:
 
```
CMake Error at cmake_install.cmake:46 (file):
  file INSTALL cannot find
  "/tmp/+a+/src/draco/src/draco//tmp/+a+/src/draco/src/draco/attributes/attribute_octahedron_transform.h":
  No such file or directory.
```
 
## Fix
 
Replace the regex-strip + re-prepend with per-element
`file(RELATIVE_PATH ...)`. Available since CMake 3.0, so no version bump
 
Fixes #1132.