### PR TITLE
fix(docs): replace broken glTF branch URL with main repo URL in draco3dgltf README

### DIFF
--- a/javascript/npm/draco3dgltf/README.md
+++ b/javascript/npm/draco3dgltf/README.md
@@ -19,7 +19,7 @@ using the Draco library to apply compression to glTF files include:
 [glTF Transform](https://gltf-transform.donmccurdy.com/), and
 [glTF Pipeline](https://github.com/CesiumGS/gltf-pipeline).
 
-Draco github glTF branch URL: https://github.com/google/draco/tree/gltf_2.0_draco_extension
+Draco github URL: https://github.com/google/draco
 
 News
 =======


### PR DESCRIPTION
The `javascript/npm/draco3dgltf/README.md` contained a link labeled "Draco github glTF branch URL" pointing to `https://github.com/google/draco/tree/gltf_2.0_draco_extension`. That branch no longer exists, so the link resolves to a 404 error for anyone following it from the npm package documentation.

The fix updates the link text to "Draco github URL" and points it to the canonical repository root `https://github.com/google/draco`, which is always valid and gives users the correct landing page for the project.

Fixes #1125
