### PR TITLE
use FindPython instead of include(FindPythonInterp)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if("${draco_root}" STREQUAL "${draco_build}")
       "And re-run CMake from the draco_build directory.")
 endif()
 
-include(FindPythonInterp)
+find_package(Python COMPONENTS Interpreter)
 include("${draco_root}/cmake/draco_build_definitions.cmake")
 include("${draco_root}/cmake/draco_cpu_detection.cmake")
 include("${draco_root}/cmake/draco_dependencies.cmake")


### PR DESCRIPTION
FindPythonInterp has been deprecated since Cmake 3.12 - [CMP0148](https://cmake.org/cmake/help/latest/policy/CMP0148.html), replaced with [FindPython](https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython)

No version bump needed since we are on 3.12 already