### PR TITLE
security: add bounds checks to decoder prediction schemes and point count

### DIFF
--- a/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_constrained_multi_parallelogram_decoder.h
+++ b/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_constrained_multi_parallelogram_decoder.h
@@ -82,7 +82,7 @@ template <typename DataTypeT, class TransformT, class MeshDataT>
 bool MeshPredictionSchemeConstrainedMultiParallelogramDecoder<
     DataTypeT, TransformT, MeshDataT>::
     ComputeOriginalValues(const CorrType *in_corr, DataTypeT *out_data,
-                          int /* size */, int num_components,
+                          int size, int num_components,
                           const PointIndex * /* entry_to_point_id_map */) {
   this->transform().Init(num_components);
 
@@ -107,6 +107,9 @@ bool MeshPredictionSchemeConstrainedMultiParallelogramDecoder<
 
   const int corner_map_size =
       static_cast<int>(this->mesh_data().data_to_corner_map()->size());
+  if (corner_map_size * num_components > size) {
+    return false;
+  }
   for (int p = 1; p < corner_map_size; ++p) {
     const CornerIndex start_corner_id =
         this->mesh_data().data_to_corner_map()->at(p);

--- a/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_geometric_normal_decoder.h
+++ b/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_geometric_normal_decoder.h
@@ -97,7 +97,7 @@ template <typename DataTypeT, class TransformT, class MeshDataT>
 bool MeshPredictionSchemeGeometricNormalDecoder<
     DataTypeT, TransformT,
     MeshDataT>::ComputeOriginalValues(const CorrType *in_corr,
-                                      DataTypeT *out_data, int /* size */,
+                                      DataTypeT *out_data, int size,
                                       int num_components,
                                       const PointIndex *entry_to_point_id_map) {
   this->SetQuantizationBits(this->transform().quantization_bits());
@@ -109,6 +109,9 @@ bool MeshPredictionSchemeGeometricNormalDecoder<
 
   const int corner_map_size =
       static_cast<int>(this->mesh_data().data_to_corner_map()->size());
+  if (corner_map_size * num_components > size) {
+    return false;
+  }
 
   VectorD<int32_t, 3> pred_normal_3d;
   int32_t pred_normal_oct[2];

--- a/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_multi_parallelogram_decoder.h
+++ b/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_multi_parallelogram_decoder.h
@@ -59,7 +59,7 @@ template <typename DataTypeT, class TransformT, class MeshDataT>
 bool MeshPredictionSchemeMultiParallelogramDecoder<DataTypeT, TransformT,
                                                    MeshDataT>::
     ComputeOriginalValues(const CorrType *in_corr, DataTypeT *out_data,
-                          int /* size */, int num_components,
+                          int size, int num_components,
                           const PointIndex * /* entry_to_point_id_map */) {
   this->transform().Init(num_components);
 
@@ -76,6 +76,9 @@ bool MeshPredictionSchemeMultiParallelogramDecoder<DataTypeT, TransformT,
 
   const int corner_map_size =
       static_cast<int>(this->mesh_data().data_to_corner_map()->size());
+  if (corner_map_size * num_components > size) {
+    return false;
+  }
   for (int p = 1; p < corner_map_size; ++p) {
     const CornerIndex start_corner_id =
         this->mesh_data().data_to_corner_map()->at(p);

--- a/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_decoder.h
+++ b/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_parallelogram_decoder.h
@@ -56,7 +56,7 @@ template <typename DataTypeT, class TransformT, class MeshDataT>
 bool MeshPredictionSchemeParallelogramDecoder<DataTypeT, TransformT,
                                               MeshDataT>::
     ComputeOriginalValues(const CorrType *in_corr, DataTypeT *out_data,
-                          int /* size */, int num_components,
+                          int size, int num_components,
                           const PointIndex * /* entry_to_point_id_map */) {
   this->transform().Init(num_components);
 
@@ -72,6 +72,9 @@ bool MeshPredictionSchemeParallelogramDecoder<DataTypeT, TransformT,
 
   const int corner_map_size =
       static_cast<int>(this->mesh_data().data_to_corner_map()->size());
+  if (corner_map_size * num_components > size) {
+    return false;
+  }
   for (int p = 1; p < corner_map_size; ++p) {
     const CornerIndex corner_id = this->mesh_data().data_to_corner_map()->at(p);
     const int dst_offset = p * num_components;

--- a/src/draco/compression/point_cloud/point_cloud_sequential_decoder.cc
+++ b/src/draco/compression/point_cloud/point_cloud_sequential_decoder.cc
@@ -24,6 +24,9 @@ bool PointCloudSequentialDecoder::DecodeGeometryData() {
   if (!buffer()->Decode(&num_points)) {
     return false;
   }
+  if (num_points < 0) {
+    return false;
+  }
   point_cloud()->set_num_points(num_points);
   return true;
 }


### PR DESCRIPTION
## Summary

This PR fixes five heap-buffer-overflow and negative-integer vulnerabilities
in the Draco 3D decoder discovered through security analysis.

### Vulnerabilities 1–4: Ignored `size` parameter in mesh prediction scheme decoders

The `ComputeOriginalValues` method in four mesh prediction scheme decoders
(`MeshPredictionSchemeParallelogramDecoder`,
`MeshPredictionSchemeConstrainedMultiParallelogramDecoder`,
`MeshPredictionSchemeMultiParallelogramDecoder`,
`MeshPredictionSchemeGeometricNormalDecoder`) had the `size` parameter
commented out (`int /* size */`) and used `corner_map_size` from mesh data
as the loop bound instead.

When `corner_map_size > size / num_components`, the loop writes past the end
of `out_data`, causing a heap buffer overflow. The corner map and attribute
arrays are both populated from compressed data, so an attacker can craft a
DRC file where they diverge.

**Fix:** Restore the `size` parameter and add a guard:
```cpp
if (corner_map_size * num_components > size) {
  return false;
}
```

### Vulnerability 5: Negative point count in PointCloudSequentialDecoder

`DecodeGeometryData` reads `num_points` as `int32_t` from the bitstream
without checking for negative values. A negative value implicitly converts
to a very large `uint32_t` when passed to `set_num_points`, causing
downstream heap overflow.

**Fix:** Reject negative point counts:
```cpp
if (num_points < 0) {
  return false;
}
```

## Testing

All 25 existing `.drc` test files in `testdata/` decode correctly with the
fixed decoder under AddressSanitizer.