### PR TITLE
Fix missing bounds checks on decoded face indices in sequential mesh decoder

### DIFF
--- a/src/draco/compression/mesh/mesh_sequential_decoder.cc
+++ b/src/draco/compression/mesh/mesh_sequential_decoder.cc
@@ -65,7 +65,7 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
     return false;
   }
   if (connectivity_method == 0) {
-    if (!DecodeAndDecompressIndices(num_faces)) {
+    if (!DecodeAndDecompressIndices(num_faces, num_points)) {
       return false;
     }
   } else {
@@ -76,6 +76,9 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
         for (int j = 0; j < 3; ++j) {
           uint8_t val;
           if (!buffer()->Decode(&val)) {
+            return false;
+          }
+          if (val >= num_points) {
             return false;
           }
           face[j] = val;
@@ -89,6 +92,9 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
         for (int j = 0; j < 3; ++j) {
           uint16_t val;
           if (!buffer()->Decode(&val)) {
+            return false;
+          }
+          if (val >= num_points) {
             return false;
           }
           face[j] = val;
@@ -105,6 +111,9 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
           if (!DecodeVarint(&val, buffer())) {
             return false;
           }
+          if (val >= num_points) {
+            return false;
+          }
           face[j] = val;
         }
         mesh()->AddFace(face);
@@ -116,6 +125,9 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
         for (int j = 0; j < 3; ++j) {
           uint32_t val;
           if (!buffer()->Decode(&val)) {
+            return false;
+          }
+          if (val >= num_points) {
             return false;
           }
           face[j] = val;
@@ -138,7 +150,8 @@ bool MeshSequentialDecoder::CreateAttributesDecoder(int32_t att_decoder_id) {
                   new LinearSequencer(point_cloud()->num_points())))));
 }
 
-bool MeshSequentialDecoder::DecodeAndDecompressIndices(uint32_t num_faces) {
+bool MeshSequentialDecoder::DecodeAndDecompressIndices(uint32_t num_faces,
+                                                       uint32_t num_points) {
   // Get decoded indices differences that were encoded with an entropy code.
   std::vector<uint32_t> indices_buffer(num_faces * 3);
   if (!DecodeSymbols(num_faces * 3, 1, buffer(), indices_buffer.data())) {
@@ -167,6 +180,10 @@ bool MeshSequentialDecoder::DecodeAndDecompressIndices(uint32_t num_faces) {
         }
       }
       const int32_t index_value = index_diff + last_index_value;
+      if (index_value < 0 ||
+          static_cast<uint32_t>(index_value) >= num_points) {
+        return false;
+      }
       face[j] = index_value;
       last_index_value = index_value;
     }

--- a/src/draco/compression/mesh/mesh_sequential_decoder.h
+++ b/src/draco/compression/mesh/mesh_sequential_decoder.h
@@ -30,8 +30,9 @@ class MeshSequentialDecoder : public MeshDecoder {
 
  private:
   // Decodes face indices that were compressed with an entropy code.
+  // |num_points| is used to validate that every decoded index is in range.
   // Returns false on error.
-  bool DecodeAndDecompressIndices(uint32_t num_faces);
+  bool DecodeAndDecompressIndices(uint32_t num_faces, uint32_t num_points);
 };
 
 }  // namespace draco


### PR DESCRIPTION
## Summary

Two missing bounds checks in `MeshSequentialDecoder::DecodeConnectivity` allow
attacker-controlled face indices from a malformed `.drc` file to exceed
`num_points`, resulting in a heap out-of-bounds read (verified crash under
AddressSanitizer; silent memory corruption on release builds).

### Fix 1 — raw index paths (`mesh_sequential_decoder.cc` ~line 81)

The uncompressed connectivity paths (8-bit, 16-bit, varint, and 32-bit
branches) decoded each face index `val` directly from the bitstream without
checking `val < num_points`.  A check is now added immediately after each
successful decode:

```cpp
if (val >= num_points) {
  return false;
}
```

### Fix 2 — entropy-compressed path (`mesh_sequential_decoder.cc` ~line 170)

`DecodeAndDecompressIndices` reconstructed absolute indices via delta-decode
but never validated the result against `num_points`.  The method now accepts
`num_points` as a second `uint32_t` parameter and rejects any index outside
`[0, num_points)`:

```cpp
if (index_value < 0 ||
    static_cast<uint32_t>(index_value) >= num_points) {
  return false;
}
```

The declaration in `mesh_sequential_decoder.h` is updated to match.

## Affected files

- `src/draco/compression/mesh/mesh_sequential_decoder.cc`
- `src/draco/compression/mesh/mesh_sequential_decoder.h`