### PR TITLE
Fix invalid pointer dereference in OBJ decoder for faces without vertices

### DIFF
--- a/src/draco/io/obj_decoder.cc
+++ b/src/draco/io/obj_decoder.cc
@@ -107,6 +107,10 @@ Status ObjDecoder::DecodeInternal() {
   }
 
   bool use_identity_mapping = false;
+  if (num_obj_faces_ > 0 && num_positions_ == 0) {
+    return Status(Status::DRACO_ERROR,
+                  "Faces reference vertex positions but none are defined.");
+  }
   if (num_obj_faces_ == 0) {
     // Mesh has no faces. In this case we try to read the geometry as a point
     // cloud where every attribute entry is a point.
@@ -639,13 +643,19 @@ void ObjDecoder::MapPointToVertexIndices(
   // point is mapped directly to the specified attribute index. Negative input
   // indices indicate addressing from the last element (e.g. -1 is the last
   // attribute value of a given type, -2 the second last, etc.).
+  if (pos_att_id_ < 0) {
+    return;
+  }
   if (indices[0] > 0) {
     out_point_cloud_->attribute(pos_att_id_)
         ->SetPointMapEntry(vert_id, AttributeValueIndex(indices[0] - 1));
   } else if (indices[0] < 0) {
+    const int32_t resolved = num_positions_ + indices[0];
+    if (resolved < 0) {
+      return;
+    }
     out_point_cloud_->attribute(pos_att_id_)
-        ->SetPointMapEntry(vert_id,
-                           AttributeValueIndex(num_positions_ + indices[0]));
+        ->SetPointMapEntry(vert_id, AttributeValueIndex(resolved));
   }
 
   if (tex_att_id_ >= 0) {


### PR DESCRIPTION
## Summary

`ObjDecoder` crashes when an OBJ file contains face definitions (`f 1 2 3`) but no preceding vertex positions (`v ...`). The position attribute ID stays at its initial value of -1, and `PointCloud::attribute(-1)` dereferences out of bounds.

Additionally, negative OBJ vertex indices (e.g., `f -1 -2 -3`) are resolved against `num_positions_` without checking for underflow.

## Changes

- After the counting pass, reject files that have faces but zero vertex positions (early error instead of UB)
- Guard `MapPointToVertexIndices` against `pos_att_id_ < 0`
- Validate that resolved negative indices are non-negative before use

## Reproduction

```bash
# Build with ASAN
cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
  -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer" \
  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" .
cmake --build build

# 8-byte OBJ file triggers SEGV
printf 'f 1 2 3\n' > crash.obj
./build/draco_encoder -i crash.obj
```

ASAN trace (before fix):
```
==PID==ERROR: AddressSanitizer: SEGV on unknown address 0xfffffffffffffff8
    #0 in draco::PointCloud::attribute(int) point_cloud.h:89
    #1 in draco::ObjDecoder::MapPointToVertexIndices obj_decoder.cc:643
    #2 in draco::ObjDecoder::ParseFace obj_decoder.cc:450
```