### PR TITLE
Fix heap OOB read in PLY reader from unchecked list entry count

### DIFF
--- a/src/draco/io/ply_reader.cc
+++ b/src/draco/io/ply_reader.cc
@@ -194,20 +194,32 @@ bool PlyReader::ParseElementData(DecoderBuffer *buffer, int element_index) {
       if (prop.is_list()) {
         // Parse the number of entries for the list element.
         int64_t num_entries = 0;
-        buffer->Decode(&num_entries, prop.list_data_type_num_bytes());
+        if (!buffer->Decode(&num_entries, prop.list_data_type_num_bytes())) {
+          return false;
+        }
+        if (num_entries < 0) {
+          return false;
+        }
+        const int64_t entry_size = prop.data_type_num_bytes();
+        if (entry_size <= 0 ||
+            num_entries > buffer->remaining_size() / entry_size) {
+          return false;
+        }
+        const int64_t num_bytes_to_read = entry_size * num_entries;
         // Store offset to the main data entry.
         prop.list_data_.push_back(prop.data_.size() /
                                   prop.data_type_num_bytes_);
         // Store the number of entries.
         prop.list_data_.push_back(num_entries);
-        // Read and store the actual property data
-        const int64_t num_bytes_to_read =
-            prop.data_type_num_bytes() * num_entries;
+        // Read and store the actual property data.
         prop.data_.insert(prop.data_.end(), buffer->data_head(),
                           buffer->data_head() + num_bytes_to_read);
         buffer->Advance(num_bytes_to_read);
       } else {
-        // Non-list property
+        // Non-list property.
+        if (buffer->remaining_size() < prop.data_type_num_bytes()) {
+          return false;
+        }
         prop.data_.insert(prop.data_.end(), buffer->data_head(),
                           buffer->data_head() + prop.data_type_num_bytes());
         buffer->Advance(prop.data_type_num_bytes());


### PR DESCRIPTION
## Summary

`PlyReader::ParseElementData` reads a list entry count from the PLY file and uses it to compute how many bytes to copy from the buffer, without checking that the buffer actually contains that much data. A PLY file with a large list count and truncated data triggers a heap-buffer-overflow read. The `Decode()` return value for the count itself was also silently ignored.

The same issue exists for non-list properties: `data_type_num_bytes()` bytes are copied from the buffer without checking `remaining_size()`.

## Changes

- Check the `Decode()` return value when reading the list entry count
- Reject negative entry counts
- Validate that `num_bytes_to_read <= remaining_size()` before the copy (also prevents integer overflow in the multiplication)
- Add a `remaining_size()` check for non-list property reads

## Reproduction

```bash
# Build with ASAN
cmake -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
  -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer" \
  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" .
cmake --build build

# Binary PLY with large list count, truncated data
printf 'ply\nformat binary_little_endian 1.0\nelement v 1\nproperty list uchar int i\nend_header\n\xff\x41\x41\x41' > crash.ply
./build/draco_encoder -i crash.ply
```

ASAN trace (before fix):
```
==PID==ERROR: AddressSanitizer: heap-buffer-overflow on address ...
READ of size 16 at ... thread T0
    #0 in draco::PlyReader::ParseElementData ply_reader.cc:206
    #1 in draco::PlyReader::ParsePropertiesData ply_reader.cc:177
    #2 in draco::PlyReader::Read ply_reader.cc:71
```