### PR TITLE
Fix heap-buffer-overflow read in binary PLY list property parsing

### DIFF
--- a/src/draco/io/ply_reader.cc
+++ b/src/draco/io/ply_reader.cc
@@ -194,7 +194,9 @@ bool PlyReader::ParseElementData(DecoderBuffer *buffer, int element_index) {
       if (prop.is_list()) {
         // Parse the number of entries for the list element.
         int64_t num_entries = 0;
-        buffer->Decode(&num_entries, prop.list_data_type_num_bytes());
+        if (!buffer->Decode(&num_entries, prop.list_data_type_num_bytes())) {
+          return false;
+        }
         // Store offset to the main data entry.
         prop.list_data_.push_back(prop.data_.size() /
                                   prop.data_type_num_bytes_);
@@ -203,11 +205,18 @@ bool PlyReader::ParseElementData(DecoderBuffer *buffer, int element_index) {
         // Read and store the actual property data
         const int64_t num_bytes_to_read =
             prop.data_type_num_bytes() * num_entries;
+        if (num_bytes_to_read < 0 ||
+            num_bytes_to_read > buffer->remaining_size()) {
+          return false;
+        }
         prop.data_.insert(prop.data_.end(), buffer->data_head(),
                           buffer->data_head() + num_bytes_to_read);
         buffer->Advance(num_bytes_to_read);
       } else {
         // Non-list property
+        if (prop.data_type_num_bytes() > buffer->remaining_size()) {
+          return false;
+        }
         prop.data_.insert(prop.data_.end(), buffer->data_head(),
                           buffer->data_head() + prop.data_type_num_bytes());
         buffer->Advance(prop.data_type_num_bytes());

--- a/src/draco/io/ply_reader_test.cc
+++ b/src/draco/io/ply_reader_test.cc
@@ -140,4 +140,31 @@ TEST_F(PlyReaderTest, TestReaderMoreDataTypes) {
   }
 }
 
+TEST_F(PlyReaderTest, TestReaderTruncatedListData) {
+  // Binary PLY where the "face" element declares a list property whose
+  // count field claims far more entries than the remaining buffer can hold.
+  // Regression test for a heap-buffer-overflow read in
+  // PlyReader::ParseElementData(): the list count was previously used to
+  // copy data out of the input buffer without a bounds check.
+  const char kData[] =
+      "ply\n"
+      "format binary_little_endian 1.0\n"
+      "element vertex 1\n"
+      "property float x\n"
+      "property float y\n"
+      "property float z\n"
+      "element face 1\n"
+      "property list uchar int vertex_indices\n"
+      "end_header\n"
+      "\x00\x00\x80\x3f\x00\x00\x00\x40\x00\x00\x40\x40"  // vertex: 1, 2, 3
+      "\xff"      // list count claims 255 int32 entries (1020 bytes)
+      "\x41\x41"  // but only 2 bytes of data actually follow
+      ;
+  DecoderBuffer buf;
+  buf.Init(kData, sizeof(kData) - 1);
+  PlyReader reader;
+  const Status status = reader.Read(&buf);
+  ASSERT_FALSE(status.ok());
+}
+
 }  // namespace draco


### PR DESCRIPTION
## Summary
- `PlyReader::ParseElementData()` (in `src/draco/io/ply_reader.cc`) reads an attacker-controlled list count from a `property list` field in a binary PLY file, and uses it to compute the number of bytes to copy out of the input `DecoderBuffer`, without checking that the buffer actually has that many bytes remaining.
- The copy goes through `buffer->data_head()` directly (raw pointer + `std::vector::insert`) instead of a bounds-checked `Decode()`/`Peek()` call, and the return value of the one bounds-checked `Decode()` call in that path was also being discarded.
- A crafted binary `binary_little_endian` PLY file with a large list count followed by truncated data therefore causes an out-of-bounds heap read.
- This is reachable from the public `draco::ReadPointCloudFromFile` / `ReadMeshFromFile` API when loading untrusted `.ply` files.

## Fix
- Check the return value of the list-count `Decode()` call.
- Validate `num_bytes_to_read` against `buffer->remaining_size()` before copying list property data.
- Add the same bounds check for non-list property data.
- Add a regression test (`PlyReaderTest.TestReaderTruncatedListData`) with a truncated list property that previously triggered the overflow.

## Verification
Reproduced locally with a small standalone driver linking `libdraco` built with `-fsanitize=address`, feeding it a crafted PLY:

```
==11878==ERROR: AddressSanitizer: container-overflow on address 0x6110000000f8 ...
READ of size 1 at 0x6110000000f8 thread T0
    ...
    #5 ... draco::PlyReader::ParseElementData(draco::DecoderBuffer*, int) ply_reader.cc:206
    #6 ... draco::PlyReader::ParsePropertiesData(draco::DecoderBuffer*) ply_reader.cc:177
    #7 ... draco::PlyReader::Read(draco::DecoderBuffer*) ply_reader.cc:71
    #8 ... draco::PlyDecoder::DecodeInternal() ply_decoder.cc:71
```

With the fix applied, the same input is rejected cleanly (`Couldn't parse properties`) instead of crashing.

## Test plan
- [x] New regression test `PlyReaderTest.TestReaderTruncatedListData` passes.
- [x] Full `draco_tests` suite (186 tests) passes under AddressSanitizer, no regressions.
- [x] Manually verified existing `testdata/*.ply` fixtures (ASCII and binary) still decode correctly with the patched reader.