### PR TITLE
Fix heap overflow in CopyDataAsFloatImpl by validating accessor bounds

### DIFF
--- a/src/draco/io/tiny_gltf_utils.h
+++ b/src/draco/io/tiny_gltf_utils.h
@@ -104,6 +104,26 @@ class TinyGltfUtils {
     const unsigned char *const data_start =
         buffer.data.data() + buffer_view.byteOffset + accessor.byteOffset;
     const int byte_stride = accessor.ByteStride(buffer_view);
+
+    // Validate that reading |accessor.count| elements with |byte_stride|
+    // does not read past the end of the buffer.
+    if (accessor.count < 0 || byte_stride <= 0) {
+      return Status(Status::DRACO_ERROR,
+                     "Error CopyDataAsFloat() invalid accessor.");
+    }
+    const size_t start_offset =
+        buffer_view.byteOffset + accessor.byteOffset;
+    if (start_offset > buffer.data.size()) {
+      return Status(Status::DRACO_ERROR,
+                     "Error CopyDataAsFloat() accessor offset out of bounds.");
+    }
+    const size_t available_bytes = buffer.data.size() - start_offset;
+    const size_t required_bytes =
+        static_cast<size_t>(byte_stride) * static_cast<size_t>(accessor.count);
+    if (required_bytes > available_bytes) {
+      return Status(Status::DRACO_ERROR,
+                     "Error CopyDataAsFloat() accessor data out of bounds.");
+    }
     const int component_size =
         tinygltf::GetComponentSizeInBytes(accessor.componentType);
 


### PR DESCRIPTION
This PR fixes a heap buffer overflow (out-of-bounds read) in 
CopyDataAsFloatImpl() in tiny_gltf_utils.h. The function did not 
validate accessor.count, byte_stride, or buffer offsets before 
reading data, which could allow reading beyond the allocated buffer 
when processing a maliciously crafted glTF file.

This issue was reported to Google via the OSS VRP program 
(Issue Tracker #543813782), and Google confirmed the vulnerability. 
The fix adds bounds validation before the read.

Full test suite passes (425/425 tests).