### PR TITLE
Fix missing return in SceneUtils::InstantiateMesh error path

### DIFF
--- a/src/draco/scene/scene_utils.cc
+++ b/src/draco/scene/scene_utils.cc
@@ -457,7 +457,7 @@ StatusOr<std::unique_ptr<Mesh>> SceneUtils::InstantiateMesh(
     const Scene &scene, const MeshInstance &instance) {
   // Check if the |scene| has base mesh corresponding to mesh |instance|.
   if (scene.NumMeshes() <= instance.mesh_index.value()) {
-    Status(Status::DRACO_ERROR, "Scene has no corresponding base mesh.");
+    return Status(Status::DRACO_ERROR, "Scene has no corresponding base mesh.");
   }
 
   // Check that mesh has valid positions.

--- a/src/draco/scene/scene_utils_test.cc
+++ b/src/draco/scene/scene_utils_test.cc
@@ -529,6 +529,18 @@ TEST(SceneUtilsTest, TestInstantiateMesh) {
   EXPECT_NEAR(instanced_bbox.GetMaxPoint()[2], +1.05800, tolerance);
 }
 
+TEST(SceneUtilsTest, TestInstantiateMeshWithInvalidMeshIndex) {
+  // Instantiating a mesh with an index that is not present in the scene must
+  // return an error instead of accessing the out-of-bounds mesh.
+  draco::Scene scene;
+  const draco::SceneUtils::MeshInstance invalid_instance = {
+      draco::MeshIndex(0), draco::SceneNodeIndex(0), 0,
+      Eigen::Matrix4d::Identity()};
+  const auto result =
+      draco::SceneUtils::InstantiateMesh(scene, invalid_instance);
+  EXPECT_FALSE(result.ok());
+}
+
 TEST(SceneUtilsTest, TestCleanupEmptyMeshGroup) {
   auto scene =
       draco::ReadSceneFromTestFile("CesiumMilkTruck/glTF/CesiumMilkTruck.gltf");


### PR DESCRIPTION
## Summary

`SceneUtils::InstantiateMesh` checks that the scene has a base mesh matching the requested `instance.mesh_index`, but the constructed error `Status` was never returned:

```cpp
if (scene.NumMeshes() <= instance.mesh_index.value()) {
  Status(Status::DRACO_ERROR, "Scene has no corresponding base mesh.");  // discarded
}
```

The bounds check was therefore a no-op and execution continued to `scene.GetMesh(instance.mesh_index)`, which performs an unchecked `meshes_[index]` access and crashes on an out-of-range index.

This fix returns the error status as the surrounding code clearly intends, and adds a regression test that instantiates a mesh with an index not present in the scene.

## Verification

Built `draco_tests` (MinGW, `DRACO_TRANSCODER_SUPPORTED=ON`):
- Without the fix, the new `SceneUtilsTest.TestInstantiateMeshWithInvalidMeshIndex` test segfaults (exit code 139) due to the out-of-bounds access.
- With the fix, the test passes and `InstantiateMesh` returns an error status.

The existing `TestInstantiateMesh` and `TestInstantiateMeshWithIdentityTransformation` tests are unaffected.