### PR TITLE
Fix OOB reads in sequential mesh decoder and rANS entropy decoder

### DIFF
--- a/src/draco/compression/entropy/ans.h
+++ b/src/draco/compression/entropy/ans.h
@@ -441,6 +441,9 @@ class RAnsDecoder {
       ans_.buf_offset = offset - 3;
       ans_.state = mem_get_le24(buf + offset - 3) & 0x3FFFFF;
     } else if (x == 3) {
+      if (offset < 4) {
+        return 1;
+      }
       ans_.buf_offset = offset - 4;
       ans_.state = mem_get_le32(buf + offset - 4) & 0x3FFFFFFF;
     } else {

--- a/src/draco/compression/mesh/mesh_sequential_decoder.cc
+++ b/src/draco/compression/mesh/mesh_sequential_decoder.cc
@@ -78,6 +78,9 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
           if (!buffer()->Decode(&val)) {
             return false;
           }
+          if (val >= num_points) {
+            return false;
+          }
           face[j] = val;
         }
         mesh()->AddFace(face);
@@ -89,6 +92,9 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
         for (int j = 0; j < 3; ++j) {
           uint16_t val;
           if (!buffer()->Decode(&val)) {
+            return false;
+          }
+          if (val >= num_points) {
             return false;
           }
           face[j] = val;
@@ -105,6 +111,9 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
           if (!DecodeVarint(&val, buffer())) {
             return false;
           }
+          if (val >= num_points) {
+            return false;
+          }
           face[j] = val;
         }
         mesh()->AddFace(face);
@@ -116,6 +125,9 @@ bool MeshSequentialDecoder::DecodeConnectivity() {
         for (int j = 0; j < 3; ++j) {
           uint32_t val;
           if (!buffer()->Decode(&val)) {
+            return false;
+          }
+          if (val >= num_points) {
             return false;
           }
           face[j] = val;


### PR DESCRIPTION
## Summary

Two out-of-bounds read bugs in the Draco decoder, both confirmed under AddressSanitizer.

## Bug 1: Face index validation missing in sequential decoder

`mesh_sequential_decoder.cc` — face vertex indices decoded from the bitstream are not validated against `num_points`. A crafted `.drc` file with face indices exceeding the vertex count causes heap-buffer-overflow when attributes are accessed via the invalid indices.

**Fix:** Add `if (val >= num_points) return false;` to all four face index decode paths (uint8, uint16, varint, uint32).

## Bug 2: Missing bounds check in rANS decoder `read_init()`

`ans.h` — `RAnsDecoder::read_init()` checks `offset < 2` for x==1 and `offset < 3` for x==2, but is missing the equivalent `offset < 4` check for x==3. A crafted entropy stream reads 4 bytes before the buffer start.

**Fix:** Add `if (offset < 4) return 1;` for the x==3 case, matching the existing pattern.