### PR TITLE
Add fuzz targets for OBJ, PLY, STL, and animation decoders

### DIFF
--- a/src/draco/tools/fuzz/draco_animation_decoder_fuzzer.cc
+++ b/src/draco/tools/fuzz/draco_animation_decoder_fuzzer.cc
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "draco/src/draco/animation/keyframe_animation.h"
+#include "draco/src/draco/animation/keyframe_animation_decoder.h"
+#include "draco/src/draco/compression/config/decoder_options.h"
+#include "draco/src/draco/core/decoder_buffer.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  draco::DecoderBuffer buffer;
+  buffer.Init(reinterpret_cast<const char *>(data), size);
+
+  draco::KeyframeAnimation animation;
+  draco::KeyframeAnimationDecoder decoder;
+  draco::DecoderOptions options;
+  decoder.Decode(options, &buffer, &animation);
+
+  return 0;
+}

--- a/src/draco/tools/fuzz/draco_obj_decoder_fuzzer.cc
+++ b/src/draco/tools/fuzz/draco_obj_decoder_fuzzer.cc
@@ -1,0 +1,29 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "draco/src/draco/core/decoder_buffer.h"
+#include "draco/src/draco/io/obj_decoder.h"
+#include "draco/src/draco/mesh/mesh.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  draco::DecoderBuffer buffer;
+  buffer.Init(reinterpret_cast<const char *>(data), size);
+
+  draco::Mesh mesh;
+  draco::ObjDecoder decoder;
+  decoder.set_use_metadata(true);
+  decoder.DecodeFromBuffer(&buffer, &mesh);
+
+  return 0;
+}

--- a/src/draco/tools/fuzz/draco_ply_decoder_fuzzer.cc
+++ b/src/draco/tools/fuzz/draco_ply_decoder_fuzzer.cc
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "draco/src/draco/core/decoder_buffer.h"
+#include "draco/src/draco/io/ply_decoder.h"
+#include "draco/src/draco/mesh/mesh.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  draco::DecoderBuffer buffer;
+  buffer.Init(reinterpret_cast<const char *>(data), size);
+
+  draco::Mesh mesh;
+  draco::PlyDecoder decoder;
+  decoder.DecodeFromBuffer(&buffer, &mesh);
+
+  return 0;
+}

--- a/src/draco/tools/fuzz/draco_stl_decoder_fuzzer.cc
+++ b/src/draco/tools/fuzz/draco_stl_decoder_fuzzer.cc
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "draco/src/draco/core/decoder_buffer.h"
+#include "draco/src/draco/io/stl_decoder.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  draco::DecoderBuffer buffer;
+  buffer.Init(reinterpret_cast<const char *>(data), size);
+
+  draco::StlDecoder decoder;
+  decoder.DecodeFromBuffer(&buffer);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Add four new fuzz harnesses to `src/draco/tools/fuzz/` covering the I/O
format decoders and animation decoder that currently have no fuzz coverage:

- `draco_obj_decoder_fuzzer.cc` — OBJ text format parser
- `draco_ply_decoder_fuzzer.cc` — PLY binary/text format parser
- `draco_stl_decoder_fuzzer.cc` — STL binary/ASCII format parser
- `draco_animation_decoder_fuzzer.cc` — Keyframe animation decoder

## Rationale

The existing four fuzz targets cover only the compressed `.drc` format
(`draco::Decoder::DecodeMeshFromBuffer` / `DecodePointCloudFromBuffer`).
The OBJ, PLY, and STL decoders accept untrusted file data from the same
sources (web, file imports) and have complex text/binary parsing logic
that would benefit from continuous fuzzing. The animation decoder shares
the compressed-format internal decompression path but through a separate
entry point that exercises keyframe-specific attribute handling.

## Build integration

No CMake or build system changes needed — the existing
`src/draco/tools/fuzz/build.sh` (used by oss-fuzz) automatically
compiles all `*.cc` files in the fuzz directory. The new harnesses
follow the same pattern and include paths as the existing four.

## Context

This was requested by the oss-fuzz maintainer (@DavidKorczynski) in
https://github.com/google/oss-fuzz/pull/16096 — harnesses should live
upstream so oss-fuzz builds them from the main repository.