### PR TITLE
fix(kdtree): guard against zero-dimensional attributes and heap-allocate decoder (fixes #1103)

### DIFF
--- a/src/draco/compression/attributes/kd_tree_attributes_decoder.cc
+++ b/src/draco/compression/attributes/kd_tree_attributes_decoder.cc
@@ -198,6 +198,9 @@ bool KdTreeAttributesDecoder::DecodePortableAttributes(
                               data_size, num_components);
     total_dimensionality += num_components;
   }
+  if (total_dimensionality == 0) {
+    return false;
+  }
   typedef PointAttributeVectorOutputIterator<uint32_t> OutIt;
   OutIt out_it(atts);
 
@@ -262,9 +265,10 @@ bool KdTreeAttributesDecoder::DecodePoints(int total_dimensionality,
                                            int num_expected_points,
                                            DecoderBuffer *in_buffer,
                                            OutIteratorT *out_iterator) {
-  DynamicIntegerPointsKdTreeDecoder<level_t> decoder(total_dimensionality);
-  if (!decoder.DecodePoints(in_buffer, *out_iterator, num_expected_points) ||
-      decoder.num_decoded_points() != num_expected_points) {
+  std::unique_ptr<DynamicIntegerPointsKdTreeDecoder<level_t>> decoder(
+      new DynamicIntegerPointsKdTreeDecoder<level_t>(total_dimensionality));
+  if (!decoder->DecodePoints(in_buffer, *out_iterator, num_expected_points) ||
+      decoder->num_decoded_points() != num_expected_points) {
     return false;
   }
   return true;
@@ -342,6 +346,9 @@ bool KdTreeAttributesDecoder::DecodeDataNeededByPortableTransforms(
         att, total_dimensionality, data_type, data_size, num_components);
     // everything is treated as 32bit in the encoder.
     total_dimensionality += num_components;
+  }
+  if (total_dimensionality == 0 || num_attributes == 0) {
+    return false;
   }
 
   const int att_id = GetAttributeId(0);

--- a/src/draco/compression/point_cloud/algorithms/dynamic_integer_points_kd_tree_decoder.h
+++ b/src/draco/compression/point_cloud/algorithms/dynamic_integer_points_kd_tree_decoder.h
@@ -183,6 +183,9 @@ template <int compression_level_t>
 template <class OutputIteratorT>
 bool DynamicIntegerPointsKdTreeDecoder<compression_level_t>::DecodePoints(
     DecoderBuffer *buffer, OutputIteratorT &oit, uint32_t oit_max_points) {
+  if (dimension_ == 0) {
+    return false;
+  }
   if (!buffer->Decode(&bit_length_)) {
     return false;
   }

--- a/src/draco/compression/point_cloud/point_cloud_kd_tree_encoding_test.cc
+++ b/src/draco/compression/point_cloud/point_cloud_kd_tree_encoding_test.cc
@@ -455,4 +455,20 @@ TEST_F(PointCloudKdTreeEncodingTest, TestIntKdTreeEncodingHighDimensional) {
   TestKdTreeEncoding(*pc);
 }
 
+TEST_F(PointCloudKdTreeEncodingTest, RejectZeroDimensionalAttributes) {
+  // Tests that malformed inputs with 0 total dimensions are cleanly rejected
+  // without crashing (fixes #1103).
+  const uint8_t kCorruptedData[] = {
+      0x44, 0x52, 0x41, 0x43, 0x4f, 0x02, 0x03, 0x00, 0x01, 0x00, 0x01,
+      0x00, 0x01, 0x01, 0x00, 0x01, 0x00, 0x01, 0xfa, 0x03, 0x01, 0x05,
+      0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x44, 0x72};
+  DecoderBuffer dec_buffer;
+  dec_buffer.Init(reinterpret_cast<const char *>(kCorruptedData),
+                  sizeof(kCorruptedData));
+  PointCloudKdTreeDecoder decoder;
+  std::unique_ptr<PointCloud> out_pc(new PointCloud());
+  DecoderOptions dec_options;
+  ASSERT_FALSE(decoder.Decode(dec_options, &dec_buffer, out_pc.get()).ok());
+}
+
 }  // namespace draco


### PR DESCRIPTION
### Summary of Changes

Fixes #1103 (Crash/SEGV in `draco::DecoderBuffer::Peek` / `DynamicIntegerPointsKdTreeDecoder` due to unvalidated 0-dimensional attribute decoding).

#### Problem
1. When malformed input provides 0 attributes or attributes with 0 components, `total_dimensionality` in `KdTreeAttributesDecoder` evaluates to 0. A 0-dimensional KdTree is invalid (point clouds require at least 1 spatial dimension), and passing `dimension_ == 0` into `DynamicIntegerPointsKdTreeDecoder` causes:
   - Modulo by zero in `DRACO_INCREMENT_MOD(last_axis, dimension_)`
   - Access to empty `levels_` and `base_stack_` vectors
   - Invalid iterator read/write in `PointAttributeVectorOutputIterator`
2. Instantiating `DynamicIntegerPointsKdTreeDecoder<level_t>` on the stack in `DecodePoints()` creates significant stack bloat across all compression levels (0 through 6), which can trigger stack buffer exhaustion.

#### Fix
1. Validate `total_dimensionality > 0` in `KdTreeAttributesDecoder::DecodePortableAttributes()` and `DecodeDataNeededByPortableTransforms()`.
2. Validate `dimension_ > 0` in `DynamicIntegerPointsKdTreeDecoder::DecodePoints()`.
3. Allocate `DynamicIntegerPointsKdTreeDecoder` on the heap via `std::unique_ptr` in `DecodePoints()` to minimize stack frame size.
4. Added unit test `RejectZeroDimensionalAttributes` in `src/draco/compression/point_cloud/point_cloud_kd_tree_encoding_test.cc`.
