### PR TITLE
decoder: avoid signed overflow in texture prediction

### DIFF
--- a/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_tex_coords_portable_predictor.h
+++ b/src/draco/compression/attributes/prediction_schemes/mesh_prediction_scheme_tex_coords_portable_predictor.h
@@ -174,7 +174,15 @@ bool MeshPredictionSchemeTexCoordsPortablePredictor<
         // Return false if squared length calculation would overflow.
         return false;
       }
-      const Vec2 x_uv = n_uv * pn_norm2_squared + (cn_dot_pn * pn_uv);
+      // Keep the scaled prediction arithmetic in the unsigned domain.  The
+      // decoder accepts untrusted deltas, so intermediate values may exceed
+      // the signed range even though the final wrapped value is valid for the
+      // bitstream.  Performing the addition as signed arithmetic invokes
+      // undefined behaviour on malformed input.
+      const Vec2 x_uv =
+          Vec2(Vec2u(n_uv) * pn_norm2_squared +
+               Vec2u(static_cast<uint64_t>(cn_dot_pn),
+                     static_cast<uint64_t>(cn_dot_pn)) * Vec2u(pn_uv));
       const int64_t pn_absmax_element =
           std::max(std::max(std::abs(pn[0]), std::abs(pn[1])), std::abs(pn[2]));
       if (std::abs(cn_dot_pn) >


### PR DESCRIPTION
## Summary

The minimized OSS-Fuzz testcase for issue 553263223 reaches the portable texture-coordinate predictor with untrusted values that overflow signed `int64_t` during scaled UV addition. UBSan reports the overflow in `VectorD::operator+`.

Perform the intermediate vector arithmetic in `uint64_t` before converting back to the signed vector. Valid bitstreams retain their results, while malformed geometry no longer invokes signed-overflow undefined behavior during decoding.

Validation: rebuilt Draco with AddressSanitizer and UndefinedBehaviorSanitizer and replayed the minimized point-cloud and mesh decoder harnesses without findings.

This is a Google Patch Rewards OSS-Fuzz Tier 2 patch. AI assistance was used and is disclosed.
